### PR TITLE
Installation instructions: Clone url with HTTPS

### DIFF
--- a/book/getting-started/installation.rst
+++ b/book/getting-started/installation.rst
@@ -10,7 +10,7 @@ directory.
 
 .. code-block:: bash
 
-    $ git clone git@github.com:sulu-io/sulu-standard.git
+    $ git clone https://github.com/sulu-io/sulu-standard.git
 
 After the clone has finished, you can change to the cloned directory, and
 checkout the latest version of Sulu:


### PR DESCRIPTION
Use the HTTPS clone url as recommended by GitHub, described here: https://help.github.com/articles/which-remote-url-should-i-use/