### PR TITLE
Add snippetType option to snippet content type

### DIFF
--- a/reference/content-types/snippet.rst
+++ b/reference/content-types/snippet.rst
@@ -12,7 +12,15 @@ references.
 Parameters
 ----------
 
-No parameters available
+.. list-table::
+    :header-rows: 1
+
+    * - Parameter
+      - Type
+      - Description
+    * - snippetType
+      - string
+      - The type of snippet to assign.
 
 Example
 -------
@@ -23,4 +31,8 @@ Example
         <meta>
             <title lang="en">Snippets</title>
         </meta>
+        
+        <params>
+            <param name="snippetType" value="animal"/>
+        </params>
     </property>


### PR DESCRIPTION
This PR adds the `snippetType` option to the `snippet` content type reference.