### PR TITLE
Add test your code section to contribution chapter

### DIFF
--- a/_themes/kr/layout.html
+++ b/_themes/kr/layout.html
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block sidebartoc %}
-  {% set toctree = toctree(maxdepth=4, collapse=true, includehidden=false, titles_only=true) %}
+  {% set toctree = toctree(maxdepth=4, collapse=true, includehidden=true, titles_only=true) %}
   <div id="logo"><a href="http://docs.sulu.io"><img src="{{ pathto('_static/sulu-logo.png', 1) }}" class="logo" /></a></div> 
   <h3>Table of Contents</h3>
   {% if toctree %}

--- a/developer/contributing/index.rst
+++ b/developer/contributing/index.rst
@@ -24,10 +24,9 @@ Contributing documentation
 Again see the `Symfony documentation standard`_ as a guide, but when in doubt
 just submit the PR and we will review it.
 
-**What you can find in the Developer Guide:**
-
 .. toctree::
-    :maxdepth: 1
+    :hidden:
+    :maxdepth: 2
 
     pull-requests
     test-your-code

--- a/developer/contributing/index.rst
+++ b/developer/contributing/index.rst
@@ -1,12 +1,6 @@
 Contributing
 ============
 
-.. toctree::
-    :hidden:
-    :maxdepth: 1
-
-    pull-requests
-
 All contributions are welcome!
 
 We try and stand on the shoulders of giants, this means that we generally copy the
@@ -29,6 +23,14 @@ Contributing documentation
 
 Again see the `Symfony documentation standard`_ as a guide, but when in doubt
 just submit the PR and we will review it.
+
+**What you can find in the Developer Guide:**
+
+.. toctree::
+    :maxdepth: 1
+
+    pull-requests
+    test-your-code
 
 .. _Symfony coding standards: http://symfony.com/doc/current/contributing/code/standards.html
 .. _pull request: hhttps://help.github.com/articles/using-pull-requests

--- a/developer/contributing/pull-requests.rst
+++ b/developer/contributing/pull-requests.rst
@@ -8,7 +8,7 @@ When creating a pull request:
   type is one of ``feature``, ``bugfix``, ``hotfix`` or ``enhancement``. For
   example: ``feature/what-my-pr-does``. Note that dashes should be used
   instead of spaces (not underscores).
-* Add your feature/bugfix/enhancment.
+* Add your feature/bugfix/enhancement.
 * Write tests.
 * :doc:`test-your-code`.
 * Add a line in the format of "<type> <pr-number>

--- a/developer/contributing/pull-requests.rst
+++ b/developer/contributing/pull-requests.rst
@@ -3,17 +3,21 @@ Creating a Pull Request
 
 When creating a pull request:
 
-* Use a meaningfull name for the pull request.
-* Create the pull request as soon as possible.  
-* Name the branch after the following format: ``<type>/<description>``, where
+* Clone the Sulu repository from git.
+* Add a branch and name it after the following format: ``<type>/<description>``, where
   type is one of ``feature``, ``bugfix``, ``hotfix`` or ``enhancement``. For
   example: ``feature/what-my-pr-does``. Note that dashes should be used
   instead of spaces (not underscores).
+* Add your feature/bugfix/enhancment.
+* Write tests.
+* :doc:`test-your-code`.
 * Add a line in the format of "<type> <pr-number>
   [<affected bundle or component>] <description>" to the ``CHANGELOG.md`` file
-  in the root directory
+  in the root directory.
 * In case you have some changes breaking backwards compability you also have to
-  add a description to the ``UPGRADE.md`` file in the root directory
+  add a description to the ``UPGRADE.md`` file in the root directory.
+* Use a meaningful name for the pull request.
+* Create the pull request as soon as possible.
 
 If you are a member of the `Sulu organization`_ you should also:
 

--- a/developer/contributing/test-your-code.rst
+++ b/developer/contributing/test-your-code.rst
@@ -11,8 +11,9 @@ For running the tests, follow these steps:
 
 3. Run the tests with ``./bin/runtests.sh``. This command has two possible options:
 
-   * ``-i``: Initialize the database and run all tests.
+   * ``-i``: Initialize the test setup (e.g. creating database).
    * ``-t [Bundle]``: Run the tests only for the specific bundle.
+   * ``-a``: Run all tests.
 
 Configure tests
 -----------------------

--- a/developer/contributing/test-your-code.rst
+++ b/developer/contributing/test-your-code.rst
@@ -25,7 +25,7 @@ to let Symfony override default parameters:
 
     $ SYMFONY__PHPCR_BACKEND_URL=http://localhost:8888/server/ ./bin/runtests.sh
 
-More information in the `Symfony docs`_. For a list of available parameters take a look into the ``parameter.yml``.
+More information in the `Symfony docs`_. For a list of available parameters take a look into the `parameter.yml`_.
 
 .. _Symfony docs: http://symfony.com/doc/current/cookbook/configuration/external_parameters.html
 .. _parameter.yml: https://github.com/sulu-io/sulu/tree/develop/src/Sulu/Bundle/TestBundle/Resources/dist/parameter.yml

--- a/developer/contributing/test-your-code.rst
+++ b/developer/contributing/test-your-code.rst
@@ -1,0 +1,31 @@
+Test your Code
+=======================
+
+For running the tests, follow these steps:
+
+1. Install Composer dependences with ``composer install``.
+
+2. Run ``./bin/jackrabbit.sh``. This will install a local copy of Jackrabbit into the ``./bin`` directory and start the
+   server. If you already have a running server on your machine, you can skip this step. Also if you want the tests to run on
+   different port than the default `8080`, you need to install Jackrabbit on your own.
+
+3. Run the tests with ``./bin/runtests.sh``. This command has two possible options:
+
+   * ``-i``: Initialize the database and run all tests.
+   * ``-t [Bundle]``: Run the tests only for the specific bundle.
+
+Configure tests
+-----------------------
+
+Sulu uses the ``SuluTestBundle`` to simplify testing. This bundle also takes care of configuration for your test
+environment. For example, if you changed the port for your Jackrabbit server to ``8888``, you can use environment variables
+to let Symfony override default parameters:
+
+.. code-block:: bash
+
+    $ SYMFONY__PHPCR_BACKEND_URL=http://localhost:8888/server/ ./bin/runtests.sh
+
+More information in the `Symfony docs`_. For a list of available parameters take a look into the ``parameter.yml``.
+
+.. _Symfony docs: http://symfony.com/doc/current/cookbook/configuration/external_parameters.html
+.. _parameter.yml: https://github.com/sulu-io/sulu/tree/develop/src/Sulu/Bundle/TestBundle/Resources/dist/parameter.yml


### PR DESCRIPTION
Add "Test your code" section to contribution chapter of the documentation, to ease contribution for new developers.

I'm not quite sure how to extend the navigation without having a `toctree` on the contribution page itself. Any ideas?