### PR TITLE
Moved parameter documentation to reference

### DIFF
--- a/book/getting-started/installation.rst
+++ b/book/getting-started/installation.rst
@@ -26,69 +26,15 @@ checkout the latest version of Sulu:
 Install dependencies
 --------------------
 
-We use `composer`_ to install the correct versions of
-Sulu's dependencies:
+Use `Composer`_ to install Sulu's dependencies:
 
 .. code-block:: bash
 
     composer install
 
-At the end of the installation you will be asked for some parameters. The
-following table describes these parameters, whereby most of the default values
-should be fine for simple installations.
-
-.. list-table::
-    :header-rows: 1
-
-    * - Parameter
-      - Description
-    * - database_driver
-      - Defines which database driver will be used
-    * - database_host
-      - The address of the server, on whch the database is running
-    * - database_port
-      - The port number to access the database on that server
-    * - database_name
-      - The name of the database
-    * - database_user
-      - The name of the database user
-    * - database_password
-      - The password of the database user
-    * - mailer_transport
-      - The protocol to send mails (currently not used)
-    * - mailer_host
-      - The server from which the mails will be sent (currently not used)
-    * - mailer_user
-      - The username for sending mails (currently not used)
-    * - mailer_password
-      - The password for sending mails (currently not used)
-    * - locale
-      - The default locale for the system
-    * - secret
-      - An unique key needed by the symfony framework
-    * - sulu_admin.name
-      - A name, which will be shown in the administration interface
-    * - sulu_admin.email
-      - Administrator email address
-    * - content_fallback_intervall
-      - The intervall in milliseconds, between content preview update in the
-        http polling mode
-    * - websocket_port
-      - The port which will be used for the content preview in the http polling mode
-    * - websocket_url
-      - The url which will be used for the content preview in the http polling mode        
-    * - phpcr_backend
-      - The PHPCR backend definition, defaults to the doctrine-dbal, check
-        http://doctrine-phpcr-odm.readthedocs.org/en/latest/reference/installation-configuration.html
-        for more configuration options
-    * - phpcr_workspace
-      - The PHPCR workspace which will be used
-    * - phpcr_user
-      - The user for phpcr
-    * - phpcr_pass
-      - The password for phpcr
-    * - phpcr_cache
-      - PHPCR caching type
+At the end of the installation, Composer asks you to submit values of different
+parameters. For now, just press "Enter" to keep their default values. You can
+learn more about each parameter in the :doc:`../../reference/parameters`.
 
 Congratulations! You have just installed Sulu. Continue with :doc:`setup` to
 setup your first Sulu website.

--- a/reference/index.rst
+++ b/reference/index.rst
@@ -12,6 +12,7 @@ The Reference aims to developers who already worked through the introdcution and
 .. toctree::
     :maxdepth: 1
 
+    parameters
     content-types/index
     twig-extensions/index
     components/document-manager/index.rst

--- a/reference/parameters.rst
+++ b/reference/parameters.rst
@@ -1,0 +1,54 @@
+Parameter Reference
+===================
+
+You can customize your Sulu installation by changing parameter values of two files:
+
+* |app/config/parameters.yml|_
+* |app/config/phpcr.yml|_
+
+This guide documents each of the keys in these files.
+
+app/config/parameters.yml
+-------------------------
+
+=================== ============================================================
+Parameter           Description
+=================== ============================================================
+database_driver     Defines which database driver will be used
+database_host       The address of the server that is running the database
+database_port       The port used to access the database on the server
+database_name       The name of the database
+database_user       The name of the database user
+database_password   The password of the database user
+mailer_transport    The protocol to send mails
+mailer_host         The server from which the mails will be sent
+mailer_user         The username for sending mails
+mailer_password     The password for sending mails
+locale              The default locale for the system
+secret              An unique key needed by the symfony framework
+sulu_admin.name     A name, which will be shown in the administration interface
+sulu_admin.email    Administrator email address
+websocket_port      The port which will be used for the content preview in the
+                    HTTP polling mode
+websocket_url       The URL which will be used for the content preview in the
+                    HTTP polling mode
+=================== ============================================================
+
+app/config/phpcr.yml
+--------------------
+
+=================== ============================================================
+Parameter           Description
+=================== ============================================================
+phpcr_backend       The PHPCR backend definition, defaults to the doctrine-dbal,
+                    check `the PHPCR documentation`_ for more configuration
+                    options
+phpcr_workspace     The PHPCR workspace which will be used
+phpcr_user          The user for phpcr
+phpcr_pass          The password for phpcr
+phpcr_cache         PHPCR caching type
+=================== ============================================================
+
+.. |app/config/parameters.yml| replace:: ``app/config/parameters.yml``
+.. |app/config/phpcr.yml| replace:: ``app/config/phpcr.yml``
+.. _the PHPCR documentation: http://doctrine-phpcr-odm.readthedocs.org/en/latest/reference/installation-configuration.html


### PR DESCRIPTION
This PR moves the description of the parameters to the reference section in order to shorten the "Getting Started" guide.

In a follow-up PR, I'd like to add a section for each parameter with an example and more specific documentation.

Open questions:

- [x] Why do we have "currently unused" parameters? Can we remove those?
- [x] Why are the two files separate? Can we merge parameters.yml and phpcr.yml?