### PR TITLE
Add new movable and collapsable flags to block description

### DIFF
--- a/reference/content-types/block.rst
+++ b/reference/content-types/block.rst
@@ -27,10 +27,16 @@ Parameters
     * - Parameter
       - Type
       - Description
-    * - add_button_text
+    * - ``add_button_text``
       -
       - Allows to adjust the text of the add button that is displayed in the administration interface.
-    * - settings_form_key
+    * - ``collapsable``
+      - boolean
+      - If set to ``true`` blocks can be collapsed, otherwise they are always expanded. Defaults to ``true``.
+    * - ``movable``
+      - boolean
+      - If set to ``true`` the position of blocks can be changed by using drag&drop, otherwise they have a fixed position. Default to ``true``.
+    * - ``settings_form_key``
       - string
       - Key of the form that should be opened in an overlay when the settings icon is clicked. Will be set to ``page_block_settings`` per default for pages.
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | ---
| Related PRs | sulu/sulu#5608
| License | MIT

#### What's in this PR?

This PR adds documentation for the `movable` and `collapsable` flags that have been introduced in #5608.