### PR TITLE
Update arguments of PageDataProvider in custom data provider docs

### DIFF
--- a/cookbook/custom-page-data-provider.rst
+++ b/cookbook/custom-page-data-provider.rst
@@ -90,6 +90,10 @@ is implemented, which filters the pages for a specific author:
                 - '@sulu_document_manager.default_session'
                 - '@sulu_page.reference_store.content'
                 - '%sulu_document_manager.show_drafts%'
+                - '%sulu_security.permissions%'
+                - '@=container.hasParameter('sulu_audience_targeting.enabled')'
+                - '@sulu_admin.form_metadata_provider'
+                - '@security.token_storage'
             tags:
                 - { name: 'sulu.smart_content.data_provider', alias: 'author_pages' }
 


### PR DESCRIPTION
The constructor of the `PageDataProvider` class were changed in https://github.com/sulu/sulu/pull/5649 and https://github.com/sulu/sulu/pull/5439