### PR TITLE
Correct documentation of template view configuration

### DIFF
--- a/book/twig.rst
+++ b/book/twig.rst
@@ -18,7 +18,7 @@ In :doc:`templates` we learned how to define a template.
 
         <key>default</key>
 
-        <view>templates/default</view>
+        <view>pages/default</view>
         <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
         ...
     </template>


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #issuenum
| Related PRs | sulu/sulu#prnum
| License | MIT

#### What's in this PR?

Correction of documentation

#### Why?

The previous view configuration did not point to the directory mentioned in the description. Instead, it pointed to `templates/templates/default.html.twig`.
