### PR TITLE
Fix image formats xml for gamma transformation

### DIFF
--- a/book/image-formats.rst
+++ b/book/image-formats.rst
@@ -199,7 +199,6 @@ Will add a gamma effect by a given `correction` parameter:
                 </transformation>
             </transformations>
         </format>
-        </format>
     </formats>
 
 Sharpen


### PR DESCRIPTION
| Q | A
| --- | ---
| License | MIT

#### What's in this PR?

Image-formats documentation: fix double `</format>` in example for gamma transformation.
