### PR TITLE
Fixed small typo - endfor instead of endif in category_selection example

### DIFF
--- a/reference/content-types/category_selection.rst
+++ b/reference/content-types/category_selection.rst
@@ -52,7 +52,7 @@ Twig
 
     {% for category in content.categories %}
         <h3>{{ category.name }}</h3>
-    {% endif %}
+    {% endfor %}
 
 If you want to list all categories in your template you can use the :doc:`../twig-extensions/functions/sulu_categories`
 twig extension for it.


### PR DESCRIPTION
    | Q                  | A
    | ------------------ | ---
    | Bug fix?           | yes
    | New feature?       | no
    | BC breaks?         | no
    | Deprecations?      | no
    | Fixed tickets      | -
    | Related issues/PRs | -
    | License            | MIT
    | Documentation PR   | -

#### What's in this PR?

Small fix of twig example for category_selection content type.

#### Why?

There was a error/typo - endif was closing for loop in twig.
The error is present in earlier version branches also. Not sure what to do about that. 
