### PR TITLE
Fix namespace imports

### DIFF
--- a/book/extend-admin.rst
+++ b/book/extend-admin.rst
@@ -353,6 +353,7 @@ because of the autoconfigure feature of Symfony:
 
     use Sulu\Bundle\AdminBundle\Admin\Admin;
     use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItemCollection;
+    use Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactoryInterface;
     use Sulu\Bundle\AdminBundle\Admin\View\ViewCollection;
 
     class EventAdmin extends Admin

--- a/cookbook/link-provider.rst
+++ b/cookbook/link-provider.rst
@@ -31,10 +31,9 @@ the list.
 
     namespace AppBundle\Link;
 
-    use Sulu\Bundle\PageBundle\Markup\Link\LinkConfiguration;
     use Sulu\Bundle\MarkupBundle\Markup\Link\LinkConfigurationBuilder;
-    use Sulu\Bundle\PageBundle\Markup\Link\LinkItem;
-    use Sulu\Bundle\PageBundle\Markup\Link\LinkProviderInterface;
+    use Sulu\Bundle\MarkupBundle\Markup\Link\LinkItem;
+    use Sulu\Bundle\MarkupBundle\Markup\Link\LinkProviderInterface;
 
     class LinkProvider implements LinkProviderInterface
     {


### PR DESCRIPTION
“PageBundle” ➔ ”MarkupBundle”, removed an unused import

| Q | A
| --- | ---
| Fixed tickets | n/a
| Related PRs | n/a
| License | MIT

#### What's in this PR?

Fixed namespace import in example code

#### Why?

Example code imported inexistent classes.
