### PR TITLE
Add extended example for Category Selection doc

### DIFF
--- a/reference/content-types/category_selection.rst
+++ b/reference/content-types/category_selection.rst
@@ -51,6 +51,7 @@ Extended Example
 Following example defines an entry category for the selection tree.
 
 .. code-block:: xml
+
     <property name="categories" type="category_selection">
         <meta>
             <title lang="en">Category Selection</title>

--- a/reference/content-types/category_selection.rst
+++ b/reference/content-types/category_selection.rst
@@ -45,6 +45,23 @@ Example
         </meta>
     </property>
 
+Extended Example
+----------------
+
+Following example defines an entry category for the selection tree.
+
+.. code-block:: xml
+    <property name="categories" type="category_selection">
+        <meta>
+            <title lang="en">Category Selection</title>
+        </meta>
+        <params>
+            <param name="request_parameters" type="collection">
+                <param name="rootKey" value="my_category_key"/>
+            </param>
+        </params>
+    </property>
+
 Twig
 ----
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | N/A
| Related PRs | N/A
| License | MIT

#### What's in this PR?

This PR add an extended example for the `category_selection` page (especially for the rootKey parameter). It's the same example as in the `single_category_selection` page.

#### Why?

This is not yet into the `category_selection` page (only in `single_category_selection`), and it might be usefull.