### PR TITLE
Add query string and anchor to MarkupBundle documentation

### DIFF
--- a/bundles/markup/index.rst
+++ b/bundles/markup/index.rst
@@ -12,11 +12,17 @@ This example contains a sulu-related example. The tag ``sulu-link`` represents
 a link to another page. This tag will be replaced via a valid anchor where the
 `href` attribute contains the UUID of the page.
 
+A query string (?) and/or an id (#) that is appended to the UUID will be
+appended to the resulting anchor.
+
 .. code-block:: html
 
     <html>
         <body>
             <sulu-link href="123-123-123" title="test-title" />
+            <sulu-link href="123-123-123?query=string&foo=bar" title="test-title" />
+            <sulu-link href="123-123-123#anchor" title="test-title" />
+            <sulu-link href="123-123-123?query=string#anchor" title="test-title" />
         </body>
     </html>
 
@@ -27,6 +33,9 @@ a link to another page. This tag will be replaced via a valid anchor where the
     <html>
         <body>
             <a href="http://example.com/test" title="test-title">Page Title</a>
+            <a href="http://example.com/test?query=string&foo=bar" title="test-title">Page Title</a>
+            <a href="http://example.com/test#anchor" title="test-title">Page Title</a>
+            <a href="http://example.com/test?query=string#anchor" title="test-title">Page Title</a>
         </body>
     </html>
 

--- a/bundles/markup/index.rst
+++ b/bundles/markup/index.rst
@@ -12,17 +12,11 @@ This example contains a sulu-related example. The tag ``sulu-link`` represents
 a link to another page. This tag will be replaced via a valid anchor where the
 `href` attribute contains the UUID of the page.
 
-A query string (?) and/or an id (#) that is appended to the UUID will be
-appended to the resulting anchor.
-
 .. code-block:: html
 
     <html>
         <body>
             <sulu-link href="123-123-123" title="test-title" />
-            <sulu-link href="123-123-123?query=string&foo=bar" title="test-title" />
-            <sulu-link href="123-123-123#anchor" title="test-title" />
-            <sulu-link href="123-123-123?query=string#anchor" title="test-title" />
         </body>
     </html>
 
@@ -33,9 +27,6 @@ appended to the resulting anchor.
     <html>
         <body>
             <a href="http://example.com/test" title="test-title">Page Title</a>
-            <a href="http://example.com/test?query=string&foo=bar" title="test-title">Page Title</a>
-            <a href="http://example.com/test#anchor" title="test-title">Page Title</a>
-            <a href="http://example.com/test?query=string#anchor" title="test-title">Page Title</a>
         </body>
     </html>
 

--- a/bundles/markup/link.rst
+++ b/bundles/markup/link.rst
@@ -3,6 +3,8 @@ sulu-link
 
 The sulu-link tag allows to link to pages and other entities in the application by their id.
 This id of the tag will be validated and replaced by a proper anchor tag when a response is generated.
+Furthermore, the sulu-link tag allows to add a query string (?) or an hash (#) that is forwarded
+to the resulting anchor.
 
 In a basic installation, the tag supports 2 different providers: ``page`` (default) and ``media``.
 Additional providers can be implemented by :doc:`registering a service with the sulu.link.provider tag<../../cookbook/link-provider>`.
@@ -16,6 +18,7 @@ Example
     <sulu-link href="123-123-123" title="test-title" />
     <sulu-link href="123-123-123" target="_blank">Link Text</sulu-link>
     <sulu-link href="123-123-123#test-anchor">Anchor Example</sulu-link>
+    <sulu-link href="123-123-123?query=test">Query String Example</sulu-link>
     <sulu-link provider="page" href="123-123-123" target="_blank">Link Text</sulu-link>
     <sulu-link provider="media" href="1" title="test-title"/>
     <sulu-link provider="media" href="1">Link Text</sulu-link>
@@ -28,6 +31,7 @@ Example
     <a href="http://example.com/test" title="test-title">Page Title</a>
     <a href="http://example.com/test" title="Page Title" target="_blank">Link Text</a>
     <a href="http://example.com/test#test-anchor" title="Page Title">Anchor Example</a>
+    <a href="http://example.com/test?query=test" title="Page Title">Query String Example</a>
     <a href="http://example.com/test" title="Page Title" target="_blank">Link Text</a>
     <a href="http://example.com/media/1/download/image.jpg?v=1" title="test-title">Media Title</a>
     <a href="http://example.com/media/1/download/image.jpg?v=1" title="Media Title">Link Text</a>


### PR DESCRIPTION
| Q | A
| --- | ---
| Related PRs | sulu/sulu#6440
| License | MIT

#### What's in this PR?

Include query string and anchor in example of Markup Bundle

#### Why?

The anchor was not mentioned previously and the query string has been added in the related pull request.
