### PR TITLE
Update the ghost_script configuration for pdf preview

### DIFF
--- a/cookbook/pdf-preview-images.rst
+++ b/cookbook/pdf-preview-images.rst
@@ -10,7 +10,8 @@ Add configuration `config/packages/sulu_media.yml`:
 .. code-block:: yaml
 
     sulu_media:
-        ghost_script: /usr/bin/gs
+        ghost_script:
+            path: /usr/bin/gs
 
 Common locations are:
 

--- a/cookbook/pdf-preview-images.rst
+++ b/cookbook/pdf-preview-images.rst
@@ -3,7 +3,7 @@ Generating thumbnails for pdf files with ghostscript
 
 Ghostscript (gs) is a PostScript and PDF language interpreter and previewer.
 Sulu is able to use the **gs** commandline program to generate thumbnail/preview images for pdf files.
-The location of the **gs** progam depends on your system and needs to be configurated for Sulu to find it.
+The location of the **gs** program depends on your system and needs to be configurated for Sulu to find it.
 
 Add configuration `config/packages/sulu_media.yml`:
 


### PR DESCRIPTION
#### What's in this PR?

The missing path is appended to ghost_script configuration.
In addition, a typo has been fixed.

#### Why?

The pdf-preview-images recipe is lacking the path 
