### PR TITLE
Remove 'to' at line 384 that appears two times

### DIFF
--- a/book/templates.rst
+++ b/book/templates.rst
@@ -381,7 +381,7 @@ from within a block.
 .. note::
 
     Because the ``&`` character needs to be escaped inside of XML files, you have to use ``AND`` instead of ``&&`` 
-    if you want to to connect conditions using a logical and. Additionally, you can use ``OR`` instead of ``||``.
+    if you want to connect conditions using a logical and. Additionally, you can use ``OR`` instead of ``||``.
 
 Language Independent Properties
 -------------------------------


### PR DESCRIPTION
Remove 'to' from the docs that appeared double in a single line.

| Q | A
| --- | ---
| Fixed tickets | fixes #issuenum
| Related PRs | sulu/sulu#prnum
| License | MIT

#### What's in this PR?

This PR fixes a typo removing the word 'to' that appeared two times.

#### Why?

To make reading that part less confusing

Which problem does the PR fix?
It fixes a typo.