### PR TITLE
Add paste_button_text param to block content type documentation

### DIFF
--- a/reference/content-types/block.rst
+++ b/reference/content-types/block.rst
@@ -30,6 +30,9 @@ Parameters
     * - ``add_button_text``
       -
       - Allows to adjust the text of the add button that is displayed in the administration interface.
+    * - ``paste_button_text``
+      -
+      - Allows to adjust the text of the paste button that is displayed in the administration interface.
     * - ``collapsable``
       - boolean
       - If set to ``true`` blocks can be collapsed, otherwise they are always expanded. Defaults to ``true``.
@@ -52,7 +55,7 @@ used by default.
 
 The other essential attribute is the ``types``-tag, which contains multiple
 ``type``-tags. A type defines some titles and its containing ``properties``,
-whereby all the available :doc:`index` can be used. These types are offered 
+whereby all the available :doc:`index` can be used. These types are offered
 to the content manager via dropdown.
 
 If collapsed the system will show the content of three properties in the block


### PR DESCRIPTION
| Q | A
| --- | ---
| Related PRs | sulu/sulu#6630
| License | MIT

#### What's in this PR?

This pull request adds the `paste_button_text` param to the documentation of the block content type. The `paste_button_text` param is added in sulu/sulu#6630.

#### Why?

See https://github.com/sulu/sulu/pull/6630