### PR TITLE
Adding documented types as types in php

### DIFF
--- a/book/extend-admin.rst
+++ b/book/extend-admin.rst
@@ -218,24 +218,12 @@ shows a controller doing what has just been described.
      */
     class EventController implements ClassResourceInterface
     {
-        private ViewHandlerInterface $viewHandler;
-
-        private FieldDescriptorFactoryInterface $fieldDescriptorFactory;
-
-        private DoctrineListBuilderFactoryInterface $listBuilderFactory;
-
-        private RestHelperInterface $restHelper;
-
         public function __construct(
-            ViewHandlerInterface $viewHandler,
-            FieldDescriptorFactoryInterface $fieldDescriptorFactory,
-            DoctrineListBuilderFactoryInterface $listBuilderFactory,
-            RestHelperInterface $restHelper
+           private ViewHandlerInterface $viewHandler,
+           private FieldDescriptorFactoryInterface $fieldDescriptorFactory,
+           private DoctrineListBuilderFactoryInterface $listBuilderFactory,
+           private RestHelperInterface $restHelper
         ) {
-            $this->viewHandler = $viewHandler;
-            $this->fieldDescriptorFactory = $fieldDescriptorFactory;
-            $this->listBuilderFactory = $listBuilderFactory;
-            $this->restHelper = $restHelper;
         }
 
         public function cgetAction(): Response
@@ -347,11 +335,8 @@ because of the autoconfigure feature of Symfony:
 
     class EventAdmin extends Admin
     {
-        private ViewBuilderFactoryInterface $viewBuilderFactory;
-
-        public function __construct(ViewBuilderFactoryInterface $viewBuilderFactory)
+        public function __construct(private ViewBuilderFactoryInterface $viewBuilderFactory)
         {
-            $this->viewBuilderFactory = $viewBuilderFactory;
         }
 
         public function configureNavigationItems(NavigationItemCollection $navigationItemCollection): void
@@ -408,11 +393,8 @@ items looks like this:
     {
         const EVENT_LIST_VIEW = 'app.events_list';
 
-        private ViewBuilderFactoryInterface $viewBuilderFactory;
-
-        public function __construct(ViewBuilderFactoryInterface $viewBuilderFactory)
+        public function __construct(private ViewBuilderFactoryInterface $viewBuilderFactory)
         {
-            $this->viewBuilderFactory = $viewBuilderFactory;
         }
 
         // ...
@@ -616,11 +598,8 @@ The following code applies all of the mentioned concepts:
         const EVENT_ADD_FORM_VIEW = 'app.event_add_form';
         const EVENT_EDIT_FORM_VIEW = 'app.event_edit_form';
 
-        private ViewBuilderFactoryInterface $viewBuilderFactory;
-
-        public function __construct(ViewBuilderFactoryInterface $viewBuilderFactory)
+        public function __construct(private ViewBuilderFactoryInterface $viewBuilderFactory)
         {
-            $this->viewBuilderFactory = $viewBuilderFactory;
         }
 
         public function configureViews(ViewCollection $viewCollection): void

--- a/book/extend-admin.rst
+++ b/book/extend-admin.rst
@@ -218,25 +218,13 @@ shows a controller doing what has just been described.
      */
     class EventController implements ClassResourceInterface
     {
-        /**
-         * @var ViewHandlerInterface
-         */
-        private $viewHandler;
+        private ViewHandlerInterface $viewHandler;
 
-        /**
-         * @var FieldDescriptorFactoryInterface
-         */
-        private $fieldDescriptorFactory;
+        private FieldDescriptorFactoryInterface $fieldDescriptorFactory;
 
-        /**
-         * @var DoctrineListBuilderFactoryInterface
-         */
-        private $listBuilderFactory;
+        private DoctrineListBuilderFactoryInterface $listBuilderFactory;
 
-        /**
-         * @var RestHelperInterface
-         */
-        private $restHelper;
+        private RestHelperInterface $restHelper;
 
         public function __construct(
             ViewHandlerInterface $viewHandler,
@@ -359,10 +347,7 @@ because of the autoconfigure feature of Symfony:
 
     class EventAdmin extends Admin
     {
-        /**
-         * @var ViewBuilderFactoryInterface
-         */
-        private $viewBuilderFactory;
+        private ViewBuilderFactoryInterface $viewBuilderFactory;
 
         public function __construct(ViewBuilderFactoryInterface $viewBuilderFactory)
         {
@@ -423,10 +408,7 @@ items looks like this:
     {
         const EVENT_LIST_VIEW = 'app.events_list';
 
-        /**
-         * @var ViewBuilderFactoryInterface
-         */
-        private $viewBuilderFactory;
+        private ViewBuilderFactoryInterface $viewBuilderFactory;
 
         public function __construct(ViewBuilderFactoryInterface $viewBuilderFactory)
         {
@@ -634,10 +616,7 @@ The following code applies all of the mentioned concepts:
         const EVENT_ADD_FORM_VIEW = 'app.event_add_form';
         const EVENT_EDIT_FORM_VIEW = 'app.event_edit_form';
 
-        /**
-         * @var ViewBuilderFactoryInterface
-         */
-        private $viewBuilderFactory;
+        private ViewBuilderFactoryInterface $viewBuilderFactory;
 
         public function __construct(ViewBuilderFactoryInterface $viewBuilderFactory)
         {

--- a/bundles/activity.rst
+++ b/bundles/activity.rst
@@ -38,14 +38,7 @@ sends an email when a page with a specific template is created in the applicatio
 
     class SendPageCreatedMailSubscriber implements EventSubscriberInterface
     {
-        /**
-         * @var MailerInterface $mailer
-         */
-        private $mailer;
-
-        public function __construct(MailerInterface $mailer) {
-            $this->mailer = $mailer;
-        }
+        public function __construct(private MailerInterface $mailer) { }
 
         public static function getSubscribedEvents()
         {
@@ -88,20 +81,10 @@ bundle and could look like this:
 
     class BookCreatedEvent extends DomainEvent
     {
-        /**
-         * @var Book
-         */
-        private $book;
-
-        /**
-         * @param mixed[] $payload
-         */
         public function __construct(
-            Book $book
+            private Book $book
         ) {
             parent::__construct();
-
-            $this->book = $book;
         }
 
         public function getEventType(): string
@@ -141,20 +124,11 @@ event. After implementing your event, you can dispatch it in your code using one
 
     class BookService
     {
-        /**
-         * @var EntityManagerInterface
-         */
-        private $entityManager;
+        private EntityManagerInterface $entityManager;
 
-        /**
-         * @var DomainEventDispatcherInterface
-         */
-        private $domainEventDispatcher;
+        private DomainEventDispatcherInterface $domainEventDispatcher;
 
-        /**
-         * @var DomainEventCollectorInterface
-         */
-        private $domainEventCollector;
+        private DomainEventCollectorInterface $domainEventCollector;
 
         public function createBook(array $data): Book
         {

--- a/bundles/preview/index.rst
+++ b/bundles/preview/index.rst
@@ -100,14 +100,8 @@ In order to display the preview in our form, we have to make use of the `Preview
         const EVENT_FORM_KEY = 'event_details';
         const EVENT_EDIT_FORM_VIEW = 'app.event_edit_form';
 
-        /**
-         * @var ViewBuilderFactoryInterface
-         */
-        private $viewBuilderFactory;
-
-        public function __construct(ViewBuilderFactoryInterface $viewBuilderFactory)
+        public function __construct(private ViewBuilderFactoryInterface $viewBuilderFactory)
         {
-            $this->viewBuilderFactory = $viewBuilderFactory;
         }
 
         public function configureViews(ViewCollection $viewCollection): void

--- a/bundles/route/custom_route_generator.rst
+++ b/bundles/route/custom_route_generator.rst
@@ -17,16 +17,10 @@ each entity type.
     class RouteGenerator implements RouteGeneratorInterface
     {
         /**
-         * @var RouteGeneratorInterface
-         */
-        private $routeGenerator;
-
-        /**
          * {@inheritdoc}
          */
-        public function __construct(RouteGeneratorInterface $routeGenerator)
+        public function __construct(private RouteGeneratorInterface $routeGenerator)
         {
-            $this->routeGenerator = $routeGenerator;
         }
 
         /**

--- a/bundles/route/index.rst
+++ b/bundles/route/index.rst
@@ -148,11 +148,8 @@ RouteDefaultsProvider
 
     class EventRouteDefaultsProvider implements RouteDefaultsProviderInterface
     {
-        protected $eventRepository;
-
-        public function __construct(EventRepository $eventRepository)
+        public function __construct(protected EventRepository $eventRepository)
         {
-            $this->eventRepository = $eventRepository;
         }
 
         public function getByEntity($entityClass, $id, $locale, $object = null)

--- a/bundles/security/security_system.rst
+++ b/bundles/security/security_system.rst
@@ -1,7 +1,7 @@
 Security System
 ===============
 
-The SecurityBundle supports to work with different security systems. Each role is assigned 
+The SecurityBundle supports to work with different security systems. Each role is assigned
 to a security system.
 When a request happens, the request is assigned to a security system and the symfony firewall allows a user to login only if the user has at least one role in the assigned security system.
 
@@ -21,7 +21,7 @@ If your webspace requires some kind of login, you should define a security syste
         <system>Website</system>
     </security>
 
-If you want to restrict pages, media entities or custom entities to logged in users with a specific role, 
+If you want to restrict pages, media entities or custom entities to logged in users with a specific role,
 you need to enable ``permission-check`` in the webspace configuration:
 
 .. code-block:: xml
@@ -35,7 +35,7 @@ To prevent caching problems with restricted entities, it is important to activat
 Custom Security System
 ----------------------
 
-You can register a custom security system in a ``Admin`` class. This is useful for sections 
+You can register a custom security system in a ``Admin`` class. This is useful for sections
 like an intranet or an extranet which are not associated to a specific webspace:
 
 .. code-block:: php
@@ -71,21 +71,13 @@ To do this, you access the ``SystemStore`` service in your listener:
 
     class SecuritySystemSubscriber implements EventSubscriberInterface
     {
-        private FirewallMap $map;
-
-        private SystemStoreInterface $systemStore;
-
         public function __construct(
-            SystemStoreInterface $systemStore,
-            FirewallMapInterface $map,
+            private SystemStoreInterface $systemStore,
+            private FirewallMapInterface $map,
         ) {
-            $this->systemStore = $systemStore;
-
             if (!$map instanceof FirewallMap) {
                 throw new \LogicException(\sprintf('Expected "%s" but got "%s".', FirewallMap::class, \get_class($map)));
             }
-
-            $this->map = $map;
         }
 
         public static function getSubscribedEvents(): array
@@ -119,4 +111,4 @@ To do this, you access the ``SystemStore`` service in your listener:
 System Store
 ------------
 
-The ``SystemStore`` service is used by the ``UserProvider`` to access the security system of the current request. It is registered with the service id ``sulu_security.system_store``. 
+The ``SystemStore`` service is used by the ``UserProvider`` to access the security system of the current request. It is registered with the service id ``sulu_security.system_store``.

--- a/cookbook/add-admin-tabs.rst
+++ b/cookbook/add-admin-tabs.rst
@@ -1,7 +1,7 @@
 Adding tabs to Sulu's Admin UI
 ==============================
 
-.. note:: 
+.. note::
 
     It is recommended to read :doc:`../book/extend-admin` beforehand to get a better understandig of how Sulu admin
     classes work.
@@ -19,9 +19,9 @@ Create the form for this view
 -----------------------------
 
 You have to create the form that is rendered in this view. Therefore create a form at
-``config/forms/page_socials.xml``. 
+``config/forms/page_socials.xml``.
 
-.. note:: 
+.. note::
 
     Note how we use slashes in the names of the properties, this returns the values in the given hierarchy.
 
@@ -83,29 +83,11 @@ The ``setFormKey`` takes a string reference, which should be the same as the key
 
     class SocialAdmin extends Admin
     {
-        /**
-        * @var ViewBuilderFactoryInterface
-        */
-        private $viewBuilderFactory;
-
-        /**
-        * @var WebspaceManagerInterface
-        */
-        private $webspaceManager;
-
-        /**
-        * @var SecurityCheckerInterface
-        */
-        private $securityChecker;
-
         public function __construct(
-            ViewBuilderFactoryInterface $viewBuilderFactory,
-            WebspaceManagerInterface $webspaceManager,
-            SecurityCheckerInterface $securityChecker
+            private ViewBuilderFactoryInterface $viewBuilderFactory,
+            private WebspaceManagerInterface $webspaceManager,
+            private SecurityCheckerInterface $securityChecker
         ) {
-            $this->viewBuilderFactory = $viewBuilderFactory;
-            $this->webspaceManager = $webspaceManager;
-            $this->securityChecker = $securityChecker;
         }
 
         public function configureViews(ViewCollection $viewCollection): void
@@ -175,24 +157,24 @@ When you debug the container right now your should see your own ``Admin`` class 
 
     $ php bin/console debug:container --tag=sulu.admin
 
-        Service ID               Class name                                           
-        sulu_contact.admin       Sulu\Bundle\ContactBundle\Admin\ContactAdmin        
-        sulu_preview.admin       Sulu\Bundle\PreviewBundle\Admin\PreviewAdmin        
-        sulu_custom_urls.admin   Sulu\Bundle\CustomUrlBundle\Admin\CustomUrlAdmin    
-        sulu_website.admin       Sulu\Bundle\WebsiteBundle\Admin\WebsiteAdmin        
-        sulu_tag.admin           Sulu\Bundle\TagBundle\Admin\TagAdmin                
-        sulu_page.admin          Sulu\Bundle\PageBundle\Admin\PageAdmin              
-        sulu_snippet.admin       Sulu\Bundle\SnippetBundle\Admin\SnippetAdmin        
-        sulu_category.admin      Sulu\Bundle\CategoryBundle\Admin\CategoryAdmin      
-        sulu_security.admin      Sulu\Bundle\SecurityBundle\Admin\SecurityAdmin      
-        sulu_media.admin         Sulu\Bundle\MediaBundle\Admin\MediaAdmin            
-        sulu_search.admin        Sulu\Bundle\SearchBundle\Admin\SearchAdmin          
-        app.social_admin         App\Admin\SocialAdmin  
+        Service ID               Class name
+        sulu_contact.admin       Sulu\Bundle\ContactBundle\Admin\ContactAdmin
+        sulu_preview.admin       Sulu\Bundle\PreviewBundle\Admin\PreviewAdmin
+        sulu_custom_urls.admin   Sulu\Bundle\CustomUrlBundle\Admin\CustomUrlAdmin
+        sulu_website.admin       Sulu\Bundle\WebsiteBundle\Admin\WebsiteAdmin
+        sulu_tag.admin           Sulu\Bundle\TagBundle\Admin\TagAdmin
+        sulu_page.admin          Sulu\Bundle\PageBundle\Admin\PageAdmin
+        sulu_snippet.admin       Sulu\Bundle\SnippetBundle\Admin\SnippetAdmin
+        sulu_category.admin      Sulu\Bundle\CategoryBundle\Admin\CategoryAdmin
+        sulu_security.admin      Sulu\Bundle\SecurityBundle\Admin\SecurityAdmin
+        sulu_media.admin         Sulu\Bundle\MediaBundle\Admin\MediaAdmin
+        sulu_search.admin        Sulu\Bundle\SearchBundle\Admin\SearchAdmin
+        app.social_admin         App\Admin\SocialAdmin
 
 You should now see the tab in the administration interface, but the data of the form is not saved yet.
 
 
-Persist the data of the form 
+Persist the data of the form
 ----------------------------
 
 In the final step, we need to persist the data of the added tab. In the case of the pages, we can utilize the existing
@@ -200,7 +182,7 @@ pages API by registering a new `StructureExtension`. In other cases, we would ne
 for the tab as shown in the :doc:`../book/extend-admin` chapter.
 
 .. code-block :: php
-    
+
     <?php
 
     class SocialStructureExtension extends AbstractExtension implements ExportExtensionInterface

--- a/cookbook/custom-page-data-provider.rst
+++ b/cookbook/custom-page-data-provider.rst
@@ -27,22 +27,15 @@ is implemented, which filters the pages for a specific author:
 
     class AuthorPageQueryBuilder extends QueryBuilder
     {
-        /**
-         * @var ContactRepositoryInterface
-         */
-        private $contactRepository;
-
         public function __construct(
             StructureManagerInterface $structureManager,
             ExtensionManagerInterface $extensionManager,
             SessionManagerInterface $sessionManager,
             $languageNamespace,
-            ContactRepositoryInterface $contactRepository
+            private ContactRepositoryInterface $contactRepository
         )
         {
             parent::__construct($structureManager, $extensionManager, $sessionManager, $languageNamespace);
-
-            $this->contactRepository = $contactRepository;
         }
 
         protected function buildWhere($webspaceKey, $locale)

--- a/cookbook/securing-your-application.rst
+++ b/cookbook/securing-your-application.rst
@@ -28,7 +28,7 @@ First of all you have to define the security context, which is represented by a
 simple string. This is done in the ``Admin`` class of your Bundle:
 
 .. code-block:: php
-    
+
     <?php
 
     namespace Acme\Bundle\ExampleBundle\Admin;
@@ -40,10 +40,10 @@ simple string. This is done in the ``Admin`` class of your Bundle:
     {
         // ...
 
-        public function getSecurityContexts()
+        public function getSecurityContexts(): array
         {
             return [
-                'Sulu' => [
+                self::SULU_ADMIN_SECURITY_SYSTEM => [
                     'Acme' => [
                         'sulu.acme.example' => [
                             PermissionTypes::VIEW,
@@ -71,7 +71,7 @@ names. This value is the key for an array containing all the available
 permission types for this security context.
 
 .. note::
-    
+
     Since the ``Admin`` class is registered as a service, you can make use of
     different services to define the available security contexts. For example
     the SuluPageBundle uses a service to create an own security context for
@@ -114,7 +114,7 @@ security context and locale to use for the permission check:
             return $request->get('locale');
         }
 
-        public function getSecurityContext()
+        public function getSecurityContext(): string
         {
             return 'sulu.acme.example';
         }
@@ -149,27 +149,27 @@ needs some updating. You can add the permission tab as shown below:
 .. code-block:: php
 
     <?php
-    
+
     namespace Sulu\Bundle\ExampleBundle\Admin;
-    
+
     use Sulu\Bundle\AdminBundle\Admin\Admin;
     use Sulu\Bundle\AdminBundle\Admin\View\ToolbarAction;
     use Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactoryInterface;
     use Sulu\Bundle\AdminBundle\Admin\View\ViewCollection;
-    
+
     class ExampleAdmin extends Admin
     {
         /**
          * @var ViewBuilderFactoryInterface
          */
         private $viewBuilderFactory;
-    
+
         public function __construct(
             ViewBuilderFactoryInterface $viewBuilderFactory,
         ) {
             $this->viewBuilderFactory = $viewBuilderFactory;
         }
-    
+
         public function configureViews(ViewCollection $viewCollection): void
         {
             // ...
@@ -229,7 +229,7 @@ Controller handling the specific type of entities:
         {
             $listBuilder = $factory->create($this->container->getParameter('sulu.model.example.class'));
             $this->get('sulu_core.doctrine_rest_helper')->initializeListBuilder($listBuilder, $this->getFieldDescriptors());
-            
+
             $listBuilder->setPermissionCheck($this->getUser(), PermissionTypes::VIEW);
 
             $listResponse = $listBuilder->execute();
@@ -249,12 +249,12 @@ Controller handling the specific type of entities:
             return $request->get('locale');
         }
 
-        public function getSecurityContext()
+        public function getSecurityContext(): string
         {
             return 'sulu.acme.example';
         }
 
-        public function getSecuredClass()
+        public function getSecuredClass(): string
         {
             return Example::class;
         }

--- a/cookbook/securing-your-application.rst
+++ b/cookbook/securing-your-application.rst
@@ -159,15 +159,8 @@ needs some updating. You can add the permission tab as shown below:
 
     class ExampleAdmin extends Admin
     {
-        /**
-         * @var ViewBuilderFactoryInterface
-         */
-        private $viewBuilderFactory;
-
-        public function __construct(
-            ViewBuilderFactoryInterface $viewBuilderFactory,
-        ) {
-            $this->viewBuilderFactory = $viewBuilderFactory;
+        public function __construct(private ViewBuilderFactoryInterface $viewBuilderFactory)
+        {
         }
 
         public function configureViews(ViewCollection $viewCollection): void

--- a/cookbook/sitemap-provider.rst
+++ b/cookbook/sitemap-provider.rst
@@ -43,17 +43,8 @@ implemented in the Repository.
 
     class SitemapProvider implements SitemapProviderInterface
     {
-        /**
-         * @var ExampleRepository
-         */
-        private $repository;
-
-        /**
-         * @param ExampleRepository $repository
-         */
-        public function __construct(ExampleRepository $repository)
+        public function __construct(private ExampleRepository $repository)
         {
-            $this->repository = $repository;
         }
 
         public function build($page, $scheme, $host)

--- a/cookbook/smart-content-data-provider.rst
+++ b/cookbook/smart-content-data-provider.rst
@@ -144,14 +144,8 @@ class implements the Interface `ItemInterface`.
      */
     class ExampleDataItem implements ItemInterface
     {
-        /**
-         * @var Example
-         */
-        private $entity;
-
-        public function __construct(Example $entity)
+        public function __construct(private Example $entity)
         {
-            $this->entity = $entity;
         }
 
         /**
@@ -220,16 +214,12 @@ to avoid filtering for these values.
      */
     class ExampleDataProvider extends BaseDataProvider
     {
-        /**
-         * @var RequestStack
-         */
-        private $requestStack;
-
-        public function __construct(DataProviderRepositoryInterface $repository, ArraySerializerInterface $serializer, RequestStack $requestStack)
-        {
+        public function __construct(
+            DataProviderRepositoryInterface $repository,
+            ArraySerializerInterface $serializer,
+            private RequestStack $requestStack
+        ) {
             parent::__construct($repository, $serializer);
-
-            $this->requestStack = $requestStack;
         }
 
         public function getConfiguration()


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | -
| Related PRs | -
| License | MIT

#### What's in this PR?

In modern PHP we want the types to be enforced with PHPs type system

#### Why?

This pull requests makes the user of the framework write modern code that is properly typed and easier to debug.
