### PR TITLE
Add notice for language switcher documentation

### DIFF
--- a/book/localization.rst
+++ b/book/localization.rst
@@ -81,9 +81,9 @@ can be used, which contains an associative array with the parameters ``locale``,
 
 .. important::
 
-    To be able to see all languages in language switcher you need to add all of these languages
-    to corresponding section in `<urls>`.
-    See :doc:`../book/webspaces` for more details.
+    The ``localizations`` variable contains the page URLs based on the URLs configured in 
+    the  ``<urls>`` section of your webspace. Have a look at :doc:`../book/webspaces` for
+    more information about the webspace configuration.
 
 The template itself does not have to be adapted for usage with multiple
 localizations. The twig variables are the same for every language, only the

--- a/book/localization.rst
+++ b/book/localization.rst
@@ -79,6 +79,12 @@ can be used, which contains an associative array with the parameters ``locale``,
     {% endfor %}
     </ul>
 
+.. important::
+
+    To be able to see all languages in language switcher you need to add all of these languages
+    to corresponding section in `<urls>`.
+    See :doc:`../book/webspaces` for more details.
+
 The template itself does not have to be adapted for usage with multiple
 localizations. The twig variables are the same for every language, only the
 content is different, and this is handled by Sulu for the developer.

--- a/cookbook/web-server/nginx.rst
+++ b/cookbook/web-server/nginx.rst
@@ -32,7 +32,7 @@ The Nginx configuration could look something like.
           access_log off;
           expires 1y;
           add_header Pragma public;
-          add_header Cache-Control "public";
+          add_header Cache-Control "public, immutable";
       }
 
       # pass the PHP scripts to FastCGI server from upstream phpfcgi


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | none
| Related PRs | none
| License | MIT

#### What's in this PR?

This PR contain improvement for language switcher section, there is short explanation that user must add all languages to <urls> section.

#### Why?

I had that issue in my project, just forget to update <urls> list and got offer from @alexander-schranz to create the PR for docs.
