### PR TITLE
Remove path variable from documentation

### DIFF
--- a/reference/twig-extensions/functions/_navigation_structure.inc
+++ b/reference/twig-extensions/functions/_navigation_structure.inc
@@ -8,5 +8,4 @@
      - **created**: Date of creation
      - **creator**: User ID of creator
      - **nodeType**: Type of node
-     - **path**: Path of page
      - **excerpt**: Excerpt (if load-excerpt is true)

--- a/reference/twig-extensions/functions/_page_structure.inc
+++ b/reference/twig-extensions/functions/_page_structure.inc
@@ -8,7 +8,6 @@
     - **changer**: User ID of changer
     - **created**: Date of creation
     - **creator**: User ID of creator
-    - **path**: Path of page
     - **localizations**: Localizations including URLs to other languages
     - **urls**: Urls of page (Deprecated)
     - **published**: Publish date of page


### PR DESCRIPTION
The `path` variable was removed in https://github.com/sulu/sulu/pull/5273