### PR TITLE
Add url to sulu_content_load example

### DIFF
--- a/reference/twig-extensions/functions/_page_structure.inc
+++ b/reference/twig-extensions/functions/_page_structure.inc
@@ -8,7 +8,6 @@
     - **changer**: User ID of changer
     - **created**: Date of creation
     - **creator**: User ID of creator
-    - **localizations**: Localizations including URLs to other languages
     - **urls**: Urls of page (Deprecated)
     - **published**: Publish date of page
     - **shadowBaseLocale**: Shadow locale of page

--- a/reference/twig-extensions/functions/sulu_content_load.rst
+++ b/reference/twig-extensions/functions/sulu_content_load.rst
@@ -8,6 +8,7 @@ Returns a Structure for the given UUID
     {% set page = sulu_content_load('1234-1234-1234-1234', {
         'title': 'title',
         'excerptTitle': 'excerpt.title',
+        'url': 'url',
     }) %}
 
 **Arguments**:

--- a/reference/twig-extensions/functions/sulu_content_load_parent.rst
+++ b/reference/twig-extensions/functions/sulu_content_load_parent.rst
@@ -5,7 +5,11 @@ Return the parent of the Structure with the given UUID
 
 .. code-block:: jinja
 
-    {% set page = sulu_content_load_parent('1234-1234-1234-1234', {'title': 'title', 'excerptTitle': 'excerpt.title'}) %}
+    {% set page = sulu_content_load_parent('1234-1234-1234-1234', {
+        'title': 'title',
+        'excerptTitle': 'excerpt.title',
+        'url': 'url',
+    }) %}
 
 **Arguments**:
 


### PR DESCRIPTION
I think it is not perfectly intuitive how to get the URL of the loaded page. I hope that adding it to the example makes it easier to find out for people.
