### PR TITLE
Fixed broken link in single_page_selection content type reference

### DIFF
--- a/reference/content-types/single_page_selection.rst
+++ b/reference/content-types/single_page_selection.rst
@@ -45,7 +45,7 @@ Twig
 ----
 
 The content type only returns the UUID of the target page at the moment. If you want to
-render a link to the page, you can use the <``sulu-link`` tag>:doc:`../../bundles/markup/link`:
+render a link to the page, you can use the ``<sulu-link>`` tag (see :doc:`../../bundles/markup/link`):
 
 .. code-block:: html
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | -
| Related PRs | -
| License | MIT

#### What's in this PR?

Fixed broken link in single_page_selection content type reference

#### Why?

The link to the documentation of the sulu-link tag could not be parsed correctly
