### PR TITLE
Added explanation how sulu-link tag is processed

### DIFF
--- a/bundles/markup/link.rst
+++ b/bundles/markup/link.rst
@@ -31,3 +31,13 @@ Example
     <a href="http://example.com/test" title="Page Title" target="_blank">Link Text</a>
     <a href="http://example.com/media/1/download/image.jpg?v=1" title="test-title">Media Title</a>
     <a href="http://example.com/media/1/download/image.jpg?v=1" title="Media Title">Link Text</a>
+
+How the tag is processed
+------------------------
+
+The ``<sulu-link>`` tag is processed after the response content is generated and
+before it is sent to the client. A parser detects all links and loads the paths of all
+linked pages from the PHPCR in a *single* query.
+
+If a twig function would be used to generate the links, each call would trigger a
+request to the PHPCR which would worsen the performance.


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | -
| Related PRs | -
| License | MIT

#### What's in this PR?

Added explanation how sulu-link tag is processed to its documentation.

#### Why?

I have asked myself (and sulu`s slack channel) why there isn't a twig function to turn UUIDs of pages into a URL. The explanation of the process (credits to @niklasnatter) helped me to understand why a twig function would be an issue.
