### PR TITLE
Added link to the block reference in the template page

### DIFF
--- a/book/templates.rst
+++ b/book/templates.rst
@@ -634,6 +634,11 @@ type:
     and set the default selection in ``default-type``. Only from the
     ``<property>``, we reference a *content type*.
 
+.. note::
+
+    More details about blocks, such as the available parameters, can be found on
+    the :doc:`reference <../reference/content-types/block>` page.
+
 Aligning Fields on the Grid
 ---------------------------
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | -
| Related PRs | -
| License | MIT

#### What's in this PR?

I have added a notice to the paragraph about blocks in the template page to link to the reference page of blocks.

#### Why?

Helps people to find extended information about blocks.
