### PR TITLE
Add controller.service_arguments tag

### DIFF
--- a/cookbook/sulu-twig-attributes.rst
+++ b/cookbook/sulu-twig-attributes.rst
@@ -13,9 +13,11 @@ attributes to your template. To do this, you can use the``TemplateAttributeResol
     use Sulu\Bundle\HttpCacheBundle\Cache\SuluHttpCache;
     use Sulu\Bundle\WebsiteBundle\Resolver\TemplateAttributeResolverInterface;
     use Symfony\Component\HttpFoundation\Response;
+    use Symfony\Component\HttpKernel\Attribute\AsController;
     use Symfony\Component\Routing\Annotation\Route;
     use Twig\Environment;
 
+    #[AsController]
     class StaticController
     {
         /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #issuenum
| Related PRs | sulu/sulu#prnum
| License | MIT

#### What's in this PR?

https://symfony.com/doc/current/controller/service.html

If your controllers don't extend the AbstractController class, you must explicitly mark your controller services as public. Alternatively, you can apply the controller.service_arguments tag to your controller services.

#### Why?

If you prefer, you can use the #[AsController] PHP attribute to automatically apply the controller.service_arguments tag to your controller services...