### PR TITLE
Add custom sorting documentation

### DIFF
--- a/cookbook/custom-page-data-provider.rst
+++ b/cookbook/custom-page-data-provider.rst
@@ -103,3 +103,106 @@ is implemented, which filters the pages for a specific author:
             <param name="provider" value="author_pages"/>
         </params>
     </property>
+
+Adding custom sorting
+---------------------
+You can implement custom sorting criteria by creating a new ``DataProvider`` class that extends from the ``PageDataProvider`` class and using it instead.
+That way, you can sort by a property that isn't provided by the ``PageDataProvider``. 
+When a lot of business logic it is probably better to create a custom entity instead.
+
+**1. Create a custom** ``DataProvider`` **class that overrides the** ``PageDataProvider`` **configuration.**
+
+.. code-block:: php
+
+    <?php
+    // src/SmartContent/CustomPageDataProvider.php
+
+    namespace App\SmartContent;
+
+    use Sulu\Bundle\PageBundle\Admin\PageAdmin;
+    use Sulu\Component\Content\SmartContent\PageDataProvider;
+    use Sulu\Component\SmartContent\Configuration\Builder;
+    use Sulu\Component\SmartContent\Configuration\ProviderConfigurationInterface;
+
+    class CustomPageDataProvider extends PageDataProvider
+    {
+        public function getConfiguration(): ProviderConfigurationInterface
+        {
+            return $this->initConfiguration();
+        }
+
+        private function initConfiguration(): ProviderConfigurationInterface
+        {
+            $builder = Builder::create()
+                ->enableTags()
+                ->enableCategories()
+                ->enableLimit()
+                ->enablePagination()
+                ->enablePresentAs()
+                ->enableDatasource('pages', 'pages', 'column_list')
+                ->enableSorting(
+                    [
+                        ['column' => null, 'title' => 'sulu_admin.default'],
+                        ['column' => 'title', 'title' => 'sulu_admin.title'],
+                        ['column' => 'published', 'title' => 'sulu_admin.published'],
+                        ['column' => 'created', 'title' => 'sulu_admin.created'],
+                        ['column' => 'changed', 'title' => 'sulu_admin.changed'],
+                        ['column' => 'authored', 'title' => 'sulu_admin.authored'],
+                        ['column' => 'customProperty', 'title' => 'sulu_admin.custom_property'],
+                    ]
+                )
+                // 
+                ->enableTypes([])
+                ->enableView(PageAdmin::EDIT_FORM_VIEW, ['id' => 'id', 'webspace' => 'webspace'])
+                ->enableAudienceTargeting();
+
+            return $builder->getConfiguration();
+        }
+    }
+
+.. list-table::
+    :header-rows: 1
+
+    * - Method
+      - Parameters
+      - Description
+    * - `enableTags`
+      - bool
+      - Enable tags to be selecteable for smart_content. Default: `true`
+    * - `enableTypes`
+      - collection
+      - Enable a list of types. Default: `[]`
+    * - `enableCategories`
+      - bool
+      - Enable categories. Default: `true`
+    * - `enableLimit`
+      - bool
+      - Enable limit. Default: `true`
+    * - `enablePagination`
+      - bool
+      - Enable pagination. Default: `true`
+    * - `enablePresentAs`
+      - bool
+      - Enable present as. Default: `true`
+    * - `enableDatasource`
+      - bool
+      - Enable datasource. Default: `true`
+    * - `enableAudienceTargeting`
+      - bool
+      - Enable audience targeting. Default: `true`
+    * - `enableSorting`
+      - collection
+      - Accepts a nested array of two-dimensional arrays. Each two-dimensional array should include a `column` key with the property to sort by, and a `title` key with the label to display in the sorting dropdown menu. Default: `[]`
+    * - `enableView`
+      -  `array<string, string> $resultToView`
+      - Defines where the deep link when clicking on a smart content item should navigate to.
+      
+**2. Use the new** ``CustomPageDataProvider`` **in the** ``services.yaml``**.**
+
+.. code-block:: yaml
+
+        app.smart_content.data_provider.author_pages:
+            class: App\SmartContent\EventPageDataProvider
+
+
+All other parameters remain the same as you would register a ``PageDataProvider`` service that uses a custom ``QueryBuilder`` implementation.

--- a/cookbook/custom-page-data-provider.rst
+++ b/cookbook/custom-page-data-provider.rst
@@ -180,12 +180,12 @@ When a lot of business logic it is probably better to create a custom entity ins
       - Enable audience targeting.
     * - `setSorting`
       - collection
-      - Accepts a nested array of two-dimensional arrays. Each two-dimensional array should include a `column` key with the property to sort by, and a `title` key with the label to display in the sorting dropdown menu. Default: `[]`
+      - Accepts a nested array of two-dimensional arrays. Each two-dimensional array should include a `column` key with the property to sort by, and a `title` key with the label to display in the sorting dropdown menu.
     * - `setView`
-      -  `array<string, string> $resultToView`
+      - `array<string, string> $resultToView`
       - Defines where the deep link when clicking on a smart content item should navigate to.
-      
-**2. Use the new** ``CustomPageDataProvider`` **in the** ``services.yaml``**.**
+
+**2. Use the custom** ``DataProvider`` **in the** ``services.yaml`` **.**
 
 .. code-block:: yaml
 

--- a/cookbook/custom-page-data-provider.rst
+++ b/cookbook/custom-page-data-provider.rst
@@ -137,22 +137,16 @@ When a lot of business logic it is probably better to create a custom entity ins
             /** @var ProviderConfiguration $configuration */
             $configuration = parent::getConfiguration();
 
-            $configuration->setTags(false);
-            $configuration->setCategories(false);
-            $configuration->setLimit(false);
-            $configuration->setPaginated(false);
-            $configuration->setPresentAs(false);
-            $configuration->setAudienceTargeting(false);
             $configuration->setSorting([
                 ...$configuration->getSorting(),
                 ['column' => 'datetimeFrom', 'title' => 'sulu_admin.datetime_from'],
             ]);
-            $configuration->setView(PageAdmin::EDIT_FORM_VIEW);
 
             return $configuration;
         }
     }
 
+Other configuration settings can be overriden as well. The available options are:
 
 .. list-table::
     :header-rows: 1

--- a/cookbook/custom-page-data-provider.rst
+++ b/cookbook/custom-page-data-provider.rst
@@ -121,10 +121,10 @@ When a lot of business logic it is probably better to create a custom entity ins
 
     use Sulu\Bundle\PageBundle\Admin\PageAdmin;
     use Sulu\Component\Content\SmartContent\PageDataProvider;
-    use Sulu\Component\SmartContent\Configuration\Builder;
+    use Sulu\Component\SmartContent\Configuration\ProviderConfiguration;
     use Sulu\Component\SmartContent\Configuration\ProviderConfigurationInterface;
 
-    class CustomPageDataProvider extends PageDataProvider
+    class EventPageDataProvider extends PageDataProvider
     {
         public function getConfiguration(): ProviderConfigurationInterface
         {
@@ -133,32 +133,25 @@ When a lot of business logic it is probably better to create a custom entity ins
 
         private function initConfiguration(): ProviderConfigurationInterface
         {
-            $builder = Builder::create()
-                ->enableTags()
-                ->enableCategories()
-                ->enableLimit()
-                ->enablePagination()
-                ->enablePresentAs()
-                ->enableDatasource('pages', 'pages', 'column_list')
-                ->enableSorting(
-                    [
-                        ['column' => null, 'title' => 'sulu_admin.default'],
-                        ['column' => 'title', 'title' => 'sulu_admin.title'],
-                        ['column' => 'published', 'title' => 'sulu_admin.published'],
-                        ['column' => 'created', 'title' => 'sulu_admin.created'],
-                        ['column' => 'changed', 'title' => 'sulu_admin.changed'],
-                        ['column' => 'authored', 'title' => 'sulu_admin.authored'],
-                        ['column' => 'customProperty', 'title' => 'sulu_admin.custom_property'],
-                    ]
-                )
-                // 
-                ->enableTypes([])
-                ->enableView(PageAdmin::EDIT_FORM_VIEW, ['id' => 'id', 'webspace' => 'webspace'])
-                ->enableAudienceTargeting();
+            /** @var ProviderConfiguration $configuration */
+            $configuration = parent::getConfiguration();
 
-            return $builder->getConfiguration();
+            $configuration->setTags(false);
+            $configuration->setCategories(false);
+            $configuration->setLimit(false);
+            $configuration->setPaginated(false);
+            $configuration->setPresentAs(false);
+            $configuration->setAudienceTargeting(false);
+            $configuration->setSorting([
+                ...$configuration->getSorting(),
+                ['column' => 'datetimeFrom', 'title' => 'sulu_admin.datetime_from'],
+            ]);
+            $configuration->setView(PageAdmin::EDIT_FORM_VIEW);
+
+            return $configuration;
         }
     }
+
 
 .. list-table::
     :header-rows: 1
@@ -166,34 +159,28 @@ When a lot of business logic it is probably better to create a custom entity ins
     * - Method
       - Parameters
       - Description
-    * - `enableTags`
+    * - `setTags`
       - bool
-      - Enable tags to be selecteable for smart_content. Default: `true`
-    * - `enableTypes`
-      - collection
-      - Enable a list of types. Default: `[]`
-    * - `enableCategories`
+      - Enable tags to be selecteable for smart_content.
+    * - `setTags`
       - bool
-      - Enable categories. Default: `true`
-    * - `enableLimit`
+      - Enable categories.
+    * - `setLimit`
       - bool
-      - Enable limit. Default: `true`
-    * - `enablePagination`
+      - Enable limit.
+    * - `setPaginated`
       - bool
-      - Enable pagination. Default: `true`
-    * - `enablePresentAs`
+      - Enable pagination.
+    * - `setPresentAs`
       - bool
-      - Enable present as. Default: `true`
-    * - `enableDatasource`
+      - Enable present as.
+    * - `setAudienceTargeting`
       - bool
-      - Enable datasource. Default: `true`
-    * - `enableAudienceTargeting`
-      - bool
-      - Enable audience targeting. Default: `true`
-    * - `enableSorting`
+      - Enable audience targeting.
+    * - `setSorting`
       - collection
       - Accepts a nested array of two-dimensional arrays. Each two-dimensional array should include a `column` key with the property to sort by, and a `title` key with the label to display in the sorting dropdown menu. Default: `[]`
-    * - `enableView`
+    * - `setView`
       -  `array<string, string> $resultToView`
       - Defines where the deep link when clicking on a smart content item should navigate to.
       

--- a/cookbook/custom-page-data-provider.rst
+++ b/cookbook/custom-page-data-provider.rst
@@ -106,6 +106,7 @@ is implemented, which filters the pages for a specific author:
 
 Adding custom sorting
 ---------------------
+
 You can implement custom sorting criteria by creating a new ``DataProvider`` class that extends from the ``PageDataProvider`` class and using it instead.
 That way, you can sort by a property that isn't provided by the ``PageDataProvider``. 
 When a lot of business logic it is probably better to create a custom entity instead.


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | N/A
| Related PRs | N/A
| License | MIT

#### What's in this PR?
Adds a section that explains how to customize the fields of smart_content that are displayed on the admin side. By making small adjustments, you can change the configuration without having to write a custom data provider with a custom entity. This can be particularly helpful when sorting needs to be done on a custom property for one of the types, or when certain functionality is fixed. For instance, you may want to overwrite the sorting method without giving the option to overwrite it with a custom QueryBuilder. These changes to the documentation file are meant to clarify and simplify the process of customizing smart_content fields on the admin side.

#### Why?

The documentation currently doesn't mention that certain parts of the DataProvider can be overwritten to make minor changes to the configuration without having to create a custom data provider. Additionally, it doesn't explain how to sort by a custom property based on one of the templates.
