### PR TITLE
Add hint about user object cached in the sessions

### DIFF
--- a/cookbook/extend-entities.rst
+++ b/cookbook/extend-entities.rst
@@ -94,6 +94,11 @@ For the `User` entity (`se_users`):
                 model: App\Entity\User
                 repository: Sulu\Bundle\SecurityBundle\Entity\UserRepository
 
+.. note::
+
+   Symfony caches the User Object in the Session clearing the sessions is so sometimes required
+   when running into ``php.CRITICAL: Uncaught Error: Failed opening required /var/project/var/cache/website/prod/doctrine/orm/Proxies/__CG__SuluBundleSecurityBundleEntityUser.php``
+
 For the `Role` entity (`se_roles`):
 
 .. code-block:: yaml

--- a/cookbook/extend-entities.rst
+++ b/cookbook/extend-entities.rst
@@ -96,7 +96,7 @@ For the `User` entity (`se_users`):
 
 .. note::
 
-   Symfony caches the User Object in the Session clearing the sessions is so sometimes required
+   Symfony caches the user object in the session, clearing the sessions is so sometimes required
    when running into ``php.CRITICAL: Uncaught Error: Failed opening required /var/project/var/cache/website/prod/doctrine/orm/Proxies/__CG__SuluBundleSecurityBundleEntityUser.php``
 
 For the `Role` entity (`se_roles`):

--- a/cookbook/extend-entities.rst
+++ b/cookbook/extend-entities.rst
@@ -96,7 +96,7 @@ For the `User` entity (`se_users`):
 
 .. note::
 
-   Symfony caches the user object in the session, clearing the sessions is so sometimes required
+   Symfony keeps the user object in the session, clearing the sessions is so sometimes required
    when running into ``php.CRITICAL: Uncaught Error: Failed opening required /var/project/var/cache/website/prod/doctrine/orm/Proxies/__CG__SuluBundleSecurityBundleEntityUser.php``
 
 For the `Role` entity (`se_roles`):

--- a/cookbook/extend-entities.rst
+++ b/cookbook/extend-entities.rst
@@ -97,7 +97,8 @@ For the `User` entity (`se_users`):
 .. note::
 
    Symfony keeps the user object in the session, clearing the sessions is so sometimes required
-   when running into ``php.CRITICAL: Uncaught Error: Failed opening required /var/project/var/cache/website/prod/doctrine/orm/Proxies/__CG__SuluBundleSecurityBundleEntityUser.php``
+   when running into ``php.CRITICAL: Uncaught Error: Failed opening required /var/project/var/cache/website/prod/doctrine/orm/Proxies/__CG__SuluBundleSecurityBundleEntityUser.php``.  
+   If use the native session storage you can use ``(php -i && php bin/console debug:config framework session) | grep save_path`` to get the configured save paths of sessions.
 
 For the `Role` entity (`se_roles`):
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #issuenum
| Related PRs | sulu/sulu#prnum
| License | MIT

#### What's in this PR?

Add hint about user object cached in the sessions.

#### Why?

Did run into this issue after deploy a project.
