### PR TITLE
Mention that snippets can not define multiple types or areas

### DIFF
--- a/reference/content-types/single_snippet_selection.rst
+++ b/reference/content-types/single_snippet_selection.rst
@@ -6,6 +6,8 @@ Description
 
 Allows to select a single snippet. Snippets are reusable pieces of content that can be included on multiple pages.
 
+Currently this content type does not support multiple areas and types.
+
 Parameters
 ----------
 

--- a/reference/content-types/snippet_selection.rst
+++ b/reference/content-types/snippet_selection.rst
@@ -7,6 +7,8 @@ Description
 Allows to select an arbitrary number of snippets. Snippets are reusable pieces of content that can be included on
 multiple pages. The assigned snippets will be saved as an array of references.
 
+Currently this content type does not support multiple areas and types.
+
 Parameters
 ----------
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #issuenum
| Related PRs | sulu/sulu#prnum
| License | MIT

#### What's in this PR?

This makes it clear, that there is currently no support for multiple types and areas.

See also:
* https://github.com/sulu/sulu/blame/2.5/src/Sulu/Bundle/SnippetBundle/Controller/SnippetController.php#L167
* https://github.com/sulu/sulu/commit/462f283882ac71d0834d1391904b5de99e15e179
* https://github.com/sulu/sulu/commit/6bb57558d019774fc4cf639476f6cda00ee00531
* https://github.com/sulu/sulu/pull/4816#issuecomment-544495549

#### Why?

It's still not mentioned in the docs.