### PR TITLE
Update webpack-encore.rst

### DIFF
--- a/cookbook/webpack-encore.rst
+++ b/cookbook/webpack-encore.rst
@@ -24,6 +24,12 @@ if that has not been done already for you by Symfony Flex:
        Symfony\WebpackEncoreBundle\WebpackEncoreBundle::class => ['all' => true],
    ];
 
+Then add the StimulusBundle as a dependency to your composer.json file.
+
+.. code:: bash
+
+   composer require symfony/stimulus-bundle
+
 Configuration
 -------------
 


### PR DESCRIPTION
Added the missing step to install StimulusBundle. 

Onwards it talks about e.g. 

assets/bootstrap.js
assets/controllers.json
assets/controllers/hello_controller.js

Which is from the StimulusBundle :)

| Q | A
| --- | ---
| Fixed tickets | fixes #issuenum
| Related PRs | sulu/sulu#prnum
| License | MIT

#### What's in this PR?

The guide explains steps of the StimulusBundle, but does not mention installing it.

#### Why?

Well.. if you strictly follow the guide. You won't find most of the files mentioned. e.g.

assets/bootstrap.js
assets/controllers.json
assets/controllers/hello_controller.js

and the change in the webpack about Stimulus.

