### PR TITLE
Add mapquest to location documentation

### DIFF
--- a/bundles/location.rst
+++ b/bundles/location.rst
@@ -17,6 +17,9 @@ Configuration
                 endpoint:             'http://open.mapquestapi.com/nominatim/v1/search.php'
             google:
                 api_key:              ''
+            mapquest:
+                api_key:              ''
+                endpoint:             'https://www.mapquestapi.com/geocoding/v1/address'
 
 Services
 --------


### PR DESCRIPTION
| Q | A
| --- | ---
| Related PRs | [sulu/sulu#prnum](https://github.com/sulu/sulu/pull/7281)
| License | MIT

#### What's in this PR?

Documentation for Mapquest API support.

#### Why?

To support Mapquest API.
