### PR TITLE
Updating single sign on documentation 

### DIFF
--- a/bundles/security/index.rst
+++ b/bundles/security/index.rst
@@ -138,6 +138,7 @@ This can be configured in the ``config/packages/security.yaml``:
    +    single_sign_on:
    +        providers:
    +            'sulu.io':
+   +                domain: 'sulu.io'
    +                dsn: 'openid://%env(resolve:SULU_OPEN_ID_CLIENT_ID)%:%env(resolve:SULU_OPEN_ID_CLIENT_SECRET)%@%env(resolve:SULU_OPEN_ID_ENDPOINT)%'
    +                default_role_key: 'USER'
 
@@ -151,6 +152,9 @@ On password reset, when the domain matches, the user is also redirected to the S
 .. note::
 
     At the moment, only the OpenID protocol is supported for Single-Sign-On authentication in Sulu.
+
+.. note::
+    The 'domain' key within the configuration is optional. However, it's recommended to specify the 'domain' key if your domain contains characters that may undergo normalization processes. For example, 'my-example.com' could become 'my_example.com' during normalization. Specifying the 'domain' key helps to avoid such issues.
 
 Two-Factor Authentication
 -------------------------


### PR DESCRIPTION
Updating single sign on documentation  with information on explicitly setting the domain via configuration.

| Q | A
| --- | ---
| License | MIT

#### What's in this PR?

This PR introduces an amendment to the documentation regarding Single Sign-On (SSO) configuration in the Sulu project.

#### Why?

The existing documentation lacked clarity regarding the configuration option for specifying the domain. This PR addresses this issue by providing explicit instructions on how to configure the domain key, which is essential for seamless integration with Single Sign-On providers. Additionally, it includes a note highlighting the importance of specifying the domain key to avoid potential normalization issues. 

I enountered the issue while following the sample in the documentation and provided a domain with "-" in it.
