### PR TITLE
Fix some basic docs styling

### DIFF
--- a/_themes/sulu/static/sulu.css_t
+++ b/_themes/sulu/static/sulu.css_t
@@ -310,19 +310,6 @@ div.sphinxsidebar #searchbox input[type="submit"] {
 }
 
 /* Basics */
-h1, h2, h3, h4, h5, h6, ul, ol, p {
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.section > * {
-    margin-top: 16px;
-}
-
-
-.section > *:first-child {
-    margin-top: 0;
-}
 
 ul {
     padding-left: 1.25em;
@@ -376,9 +363,15 @@ h6 {
 }
 
 /* Figure */
-div.figure {
-    margin: 0;
-    padding: 0;
+.align-default,
+img.align-default,
+figure.align-default,
+table.align-default {
+    margin-left: 0;
+    margin-right: 0;
+    padding-left: 0;
+    margin-right: 0;
+    text-align: left;
 }
 
 /* Img */
@@ -402,10 +395,6 @@ object.align-right {
 table {
     width: 100%;
     max-width: 75ch;
-}
-
-table.align-default {
-    margin-left: 0;
 }
 
 .sphinxsidebar code,


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #issuenum
| Related PRs | sulu/sulu#prnum
| License | MIT

#### What's in this PR?

Fix some basic docs styling.

#### Why?

The spaces between paragraphs are buggy. Images are displayed centered where they should not: https://docs.sulu.io/en/2.5/bundles/snippet.html 

Before:

![Bildschirmfoto 2024-05-21 um 16 16 52](https://github.com/sulu/sulu-docs/assets/1698337/9dc3cdb6-1fba-467c-9f04-6af657400487)

This PR:

![Bildschirmfoto 2024-05-21 um 16 16 35](https://github.com/sulu/sulu-docs/assets/1698337/4fc238ec-1da6-43a9-8e84-442be8f45743)
