### PR TITLE
Fix reference bundle paragraph spaces

### DIFF
--- a/bundles/reference.rst
+++ b/bundles/reference.rst
@@ -7,14 +7,10 @@ and location in which an entity is utilized. Presently, the ReferenceBundle is c
 Media within PHPCR entities such as `pages` and `snippets`. These references are managed distinctly for the draft
 state within the `admin context` and the live state within the `website context`.
 
-|
-
 The main reason we need this bundle is that, unlike traditional database references, our content management system
 operates on an unstructured data model. Therefore, we cannot rely solely on database references, which are usually preferred.
 It is essential to note that the ReferenceBundle should only be used for unstructured data, where database relations are
 not feasible.
-
-|
 
 Content maintainers are able to see the references to a specific entity in the `Insights` tab of an entity like `Snippet`.
 
@@ -34,7 +30,6 @@ references by executing the `bin/console sulu:references:refresh` command. This 
 
     bin/console sulu:references:refresh <resource-key>
 
-
 .. note::
 
     Please note that references are only refreshed for the current context. To refresh the references for both the
@@ -46,8 +41,6 @@ Integrating references for custom content-types
 To integrate the ReferenceBundle for custom content-types, you need to implement the `ReferenceContentTypeInterface` in your
 content-type class. The interface requires you to implement the `getReferences` method. The method already receives the
 `ReferenceCollector` which you can use to add references to the collector.
-
-|
 
 Example implementation for a custom content-type:
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #issuenum
| Related PRs | sulu/sulu#prnum
| License | MIT

#### What's in this PR?

Remove force paragraphs.


New Styling with #800 and this one:

![Bildschirmfoto 2024-05-21 um 16 26 03](https://github.com/sulu/sulu-docs/assets/1698337/01fd327b-c637-4456-90c1-97760404ae6c)

#### Why?

https://github.com/sulu/sulu-docs/pull/800 adds default paragraph styling.

The force paragraphs would add to much space:

![Bildschirmfoto 2024-05-21 um 16 25 51](https://github.com/sulu/sulu-docs/assets/1698337/0d611d35-b7e0-4417-908a-ca7c5401a644)

