### PR TITLE
Force image placement for new theme

### DIFF
--- a/_themes/sulu/static/sulu.css_t
+++ b/_themes/sulu/static/sulu.css_t
@@ -380,15 +380,17 @@ img {
 }
 
 img.align-center,
-.figure.align-center,
+figure.align-center,
 object.align-center,
 img.align-right,
-.figure.align-right,
+figure.align-right,
 object.align-right {
     max-width: 75ch;
     /* not centered */
     margin-left: 0;
     margin-right: 0;
+    padding-left: 0;
+    padding-right: 0;
 }
 
 /* Table */


### PR DESCRIPTION
| Q | A
| --- | ---
| License | MIT

#### What's in this PR?

Force image placement for new theme.

#### Why?

Sphinx theme changed from `<div class="figure">` to a `<figure>` tag and so broke existing theme changes.
