### PR TITLE
Add a hint to localization.rst how to get the current active locale

### DIFF
--- a/book/localization.rst
+++ b/book/localization.rst
@@ -70,6 +70,8 @@ For the developer the only touching points with localizations are the
 configuration and the eventual use of a language switcher on the homepage.
 For the language switcher the ``localizations`` variable delivered to the twig template
 can be used, which contains an associative array with the parameters ``locale``, ``url`` and ``country``.
+The currently active locale can be obtained from the underlying Symfony Request
+object with ``app.locale``.
 
 .. code-block:: twig
 


### PR DESCRIPTION
Hopefully preventing confusion as noted in sulu/sulu#7443

| Q | A
| --- | ---
| Fixed tickets | Prevents confusion as in #7443
| Related PRs | none
| License | MIT

#### What's in this PR?

Adds a note how to get the currently active locale in the documentation for the localizations.

#### Why?

#7443 describes the confusion about that.

(New PR for 2.5 branch)













