### PR TITLE
Add caching headers for avif images

### DIFF
--- a/cookbook/web-server/apache.rst
+++ b/cookbook/web-server/apache.rst
@@ -60,6 +60,7 @@ Let's add the Apache configuration file for the `sulu.lo` domain.
               ExpiresByType image/svg "access plus 1 year"
               ExpiresByType image/jpeg "access plus 1 year"
               ExpiresByType image/jpg "access plus 1 year"
+              ExpiresByType image/avif "access plus 1 year"
               ExpiresByType image/webp "access plus 1 year"
               ExpiresByType image/x-icon "access plus 1 year"
               ExpiresByType image/vnd.microsoft.icon "access plus 1 year"
@@ -74,7 +75,7 @@ Let's add the Apache configuration file for the `sulu.lo` domain.
           </IfModule>
 
           <IfModule mod_headers.c>
-              <filesMatch ".(ico|css|js|gif|webp|jpe?g|png|svg|woff|woff2|eot|ttf|mp4)$">
+              <filesMatch ".(ico|css|js|gif|webp|avif|jpe?g|png|svg|woff|woff2|eot|ttf|mp4)$">
                   Header set Cache-Control "public, max-age=31536000, immutable"
               </filesMatch>
 

--- a/cookbook/web-server/nginx.rst
+++ b/cookbook/web-server/nginx.rst
@@ -26,7 +26,7 @@ The Nginx configuration could look something like.
       }
 
       # expire
-      location ~* \.(?:ico|css|js|gif|webp|jpe?g|png|svg|woff|woff2|eot|ttf|mp4)$ {
+      location ~* \.(?:ico|css|js|gif|webp|avif|jpe?g|png|svg|woff|woff2|eot|ttf|mp4)$ {
           # try to serve file directly, fallback to index.php
           try_files $uri /index.php$is_args$args;
           access_log off;


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #issuenum
| Related PRs | sulu/sulu#prnum
| License | MIT

#### What's in this PR?

Add caching headers for avif images.

#### Why?

Avif should be cached same as webp.
