### PR TITLE
Fix documentation for excluding templates in Sulu 2.x

### DIFF
--- a/book/templates.rst
+++ b/book/templates.rst
@@ -40,6 +40,11 @@ The template of a page can be selected in the admin interface:
 
 .. figure:: ../img/templates-selection.png
 
+.. note::
+
+    If you don't want a template to appear in this list, use the ``excluded-templates`` node in the webspace configuration file.
+    Have a closer look at `Setup a Webspace <webspaces.html#urls>`_ for more details.
+
 The name displayed in the dropdown is configured in the ``<meta>`` section of
 the XML:
 

--- a/book/templates.rst
+++ b/book/templates.rst
@@ -40,12 +40,6 @@ The template of a page can be selected in the admin interface:
 
 .. figure:: ../img/templates-selection.png
 
-.. Caution::
-
-    A template is shown in the dropdown only if both the XML and the Twig file
-    exist! If you can't see your template, double-check the directories
-    ``config/templates/pages`` and ``templates/pages``.
-
 The name displayed in the dropdown is configured in the ``<meta>`` section of
 the XML:
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes [#888](https://github.com/sulu/sulu-docs/issues/808)
| License | MIT

#### What's in this PR?
Removal of the caution regarding the visibility of templates in the dropdown list.

#### Why?
Because since version 2.x of Sulu, this is no longer the case. You need to use the `excluded-templates` node in the webspace file.
