### PR TITLE
Removes wrong "optional" argument information for sulu_categories

### DIFF
--- a/reference/twig-extensions/functions/sulu_categories.rst
+++ b/reference/twig-extensions/functions/sulu_categories.rst
@@ -16,7 +16,7 @@ Returns all categories in the system.
 
 **Arguments**:
 
- - **locale**: *string* - Locale to resolve category
+ - **locale**: *string* - Locale to resolve categories
  - **parentKey**: *string* - If only specific categories should be loaded set a parent category key (**optional**)
 
 **Returns**: array - array of serialized Category instances

--- a/reference/twig-extensions/functions/sulu_categories.rst
+++ b/reference/twig-extensions/functions/sulu_categories.rst
@@ -16,7 +16,7 @@ Returns all categories in the system.
 
 **Arguments**:
 
- - **locale**: If item is not in the same locale as current content (**optional**)
- - **parentKey**: If only specific categories should be loaded set a parent category key (**optional**)
+ - **locale**: *string* - Locale to resolve category
+ - **parentKey**: *string* - If only specific categories should be loaded set a parent category key (**optional**)
 
 **Returns**: array - array of serialized Category instances


### PR DESCRIPTION
| Q | A
| --- | ---
| License | MIT

#### What's in this PR?

- Removes wrong information about optional argument `locale` in `sulu_categories` twig extension
- Adds type information in arguments section

#### Why?

Not passing the `locale` argument throws an error as it is mandatory (see [code](https://github.com/sulu/sulu/blob/dd62b1ae0edd9c9e6aa10b0c400891f5979f8516/src/Sulu/Bundle/CategoryBundle/Twig/CategoryTwigExtension.php#L81))
