### PR TITLE
Upgrade vhost to current supported PHP version

### DIFF
--- a/cookbook/web-server/nginx.rst
+++ b/cookbook/web-server/nginx.rst
@@ -37,7 +37,7 @@ The Nginx configuration could look something like.
 
       # pass the PHP scripts to FastCGI server from upstream phpfcgi
       location ~ ^/(index|config)\.php(/|$) {
-          fastcgi_pass unix:/var/run/php/php8.1-fpm.sock;
+          fastcgi_pass unix:/var/run/php/php8.3-fpm.sock;
           fastcgi_split_path_info ^(.+\.php)(/.*)$;
           include fastcgi_params;
           fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #issuenum
| Related PRs | sulu/sulu#prnum
| License | MIT

#### What's in this PR?

Upgrade vhost to current supported PHP version.

#### Why?

PHP 8.3 is the recommend PHP version currently and so the docs should represent that one.
