### PR TITLE
Fix CI build

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -23,7 +23,7 @@ jobs:
             - name: Sphinx Build
               run: sphinx-build -n -W --keep-going -b html -d _build/doctrees . _build/html
 
-            - uses: actions/upload-artifact@v1
+            - uses: actions/upload-artifact@v4
               with:
                   name: DocumentationHTML
                   path: "_build/html"


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #issuenum
| Related PRs | sulu/sulu#prnum
| License | MIT

#### What's in this PR?

Fix CI build.

#### Why?

CI does not longer build because action is deprecated and need be updated to newer version.
