### PR TITLE
Update default-snippets.rst

### DIFF
--- a/cookbook/default-snippets.rst
+++ b/cookbook/default-snippets.rst
@@ -64,6 +64,12 @@ Sulu includes a ``sulu_snippet_load_by_area`` twig function that allows to load 
 the default snippet for a given area. The usage of the function is documented in
 :doc:`/reference/twig-extensions/functions/sulu_snippet_load_by_area`.
 
+.. tip::
+
+        After defining a new area in the snippet template, you may have to clear the website cache with
+        ``php bin/websiteconsole cache:clear`` command. Not clearing the website cache may result in Parameter
+        not found exception.
+
 Using the default snippet as fallback value in a ``snippet_selection``
 ----------------------------------------------------------------------
 


### PR DESCRIPTION
Added informations about ``Parameter not found exception`` during rendering of the twig template with sulu_snippet_load_by_area() call after defining new area in the snippet template. Added possible solution as a tip.

| Q | A
| --- | ---
| Fixed tickets | fixes #issuenum
| Related PRs | sulu/sulu#prnum
| License | MIT

#### What's in this PR?

Added informations about ``Parameter not found exception`` during rendering of the twig template with sulu_snippet_load_by_area() call after defining new area in the snippet template. Added possible solution as a tip.

#### Why?

Spent almost two hours on trying to handle the exception. The bin/console clear:cache command didn't solve the issue, I had to call bin/website clear:cache. The resolution to the issue was brought to me by Denis Michalik on sulu slack (https://sulu-io.slack.com/archives/C0430GGCV/p1729678310918159?thread_ts=1729540188.945419&cid=C0430GGCV). I think the tip in the docs can be helpful to new sulu'ers.
