### PR TITLE
Fix commands for none unix based terminals

### DIFF
--- a/book/getting-started.rst
+++ b/book/getting-started.rst
@@ -49,7 +49,7 @@ This command will bootstrap a new project in the directory ``my-project``.
 
     .. code-block:: bash
 
-        bin/console sulu:admin:download-language
+        php bin/console sulu:admin:download-language
 
 Webspaces
 ---------
@@ -125,7 +125,7 @@ default data:
 
 .. code-block:: bash
 
-    bin/adminconsole sulu:build dev
+    php bin/adminconsole sulu:build dev
 
 .. caution::
 
@@ -134,7 +134,7 @@ default data:
 
     .. code-block:: bash
 
-        bin/adminconsole sulu:build prod
+        php bin/adminconsole sulu:build prod
 
 Optionally, you can store the content of your website (all tables starting with
 ``phpcr_``) in `Apache Jackrabbit`_. We'll get back to that later.

--- a/book/templates.rst
+++ b/book/templates.rst
@@ -228,7 +228,7 @@ Here is a table with the content types shipped in Sulu core:
 
     .. code-block:: bash
 
-        bin/adminconsole sulu:content:types:dump
+        php bin/adminconsole sulu:content:types:dump
 
 Many content types can be configured by passing parameters in the element
 ``<params>``. For a single select, for example, you need to set the possible
@@ -381,7 +381,7 @@ from within a block.
 
 .. note::
 
-    Because the ``&`` character needs to be escaped inside of XML files, you have to use ``AND`` instead of ``&&`` 
+    Because the ``&`` character needs to be escaped inside of XML files, you have to use ``AND`` instead of ``&&``
     if you want to connect conditions using a logical and. Additionally, you can use ``OR`` instead of ``||``.
 
 Language Independent Properties

--- a/cookbook/build-admin-frontend.rst
+++ b/cookbook/build-admin-frontend.rst
@@ -15,7 +15,7 @@ Sulu is shipped with a build in command to update the build.
 
 .. code-block:: bash
 
-    bin/adminconsole sulu:admin:update-build
+    php bin/adminconsole sulu:admin:update-build
 
 .. note::
 

--- a/cookbook/dump-sitemap.rst
+++ b/cookbook/dump-sitemap.rst
@@ -7,23 +7,23 @@ Each provider returns mostly 50000 links which can return many
 links, which would take a bigger amount of time. The Google bot
 does not wait a long time for the sitemap to be returned.
 
-To improve the speed of the sitemap page, Sulu provides a command for pre-generating 
+To improve the speed of the sitemap page, Sulu provides a command for pre-generating
 the page and cache it on the filesystem. The should be called in a cron-job to keep the
 pre-generated sitemap up to date.
 
 .. note::
 
-    This is a performance optimization for very big websites. In 99% of the cases, the 
-    optimization is not necessary and the sitemap can be generated on the fly. 
+    This is a performance optimization for very big websites. In 99% of the cases, the
+    optimization is not necessary and the sitemap can be generated on the fly.
 
 .. code-block:: bash
 
-    bin/websiteconsole sulu:website:dump-sitemap
+    php bin/websiteconsole sulu:website:dump-sitemap
 
 If you use the ``{host}`` replacer in your webspace url
 configuration, you need to set the Symfony ``default_uri`` config option
-for generating the URLs of your sitemap items via a command. 
-Have a look at the official Symfony Documentation about 
+for generating the URLs of your sitemap items via a command.
+Have a look at the official Symfony Documentation about
 `Generating URLs in Commands`_ for more information.
 
 .. code-block:: yaml
@@ -54,7 +54,7 @@ Switch back to on the fly generation
 If you want to switch back to on the fly generation, you need
 to remove the exist pre-generated sitemaps from the ``var`` directory.
 
-By default, pre-generated sitemaps are stored in the following directory in the 
+By default, pre-generated sitemaps are stored in the following directory in the
 ``prod`` environment:
 
 .. code-block:: bash

--- a/cookbook/jackrabbit.rst
+++ b/cookbook/jackrabbit.rst
@@ -76,36 +76,36 @@ data before changing the configuration:
 
 .. code-block:: bash
 
-    bin/adminconsole doctrine:phpcr:workspace:export -p /cmf cmf.xml
-    bin/websiteconsole doctrine:phpcr:workspace:export -p /cmf cmf_live.xml
-    bin/adminconsole doctrine:phpcr:workspace:export -p /jcr:versions jcr.xml
+    php bin/adminconsole doctrine:phpcr:workspace:export -p /cmf cmf.xml
+    php bin/websiteconsole doctrine:phpcr:workspace:export -p /cmf cmf_live.xml
+    php bin/adminconsole doctrine:phpcr:workspace:export -p /jcr:versions jcr.xml
 
 Then change the configuration as explained in the above Configuration section, and
 then execute the following command to initialize the jackrabbit workspaces for sulu:
 
 .. code-block:: bash
 
-    bin/adminconsole cache:clear
-    bin/adminconsole sulu:document:initialize
+    php bin/adminconsole cache:clear
+    php bin/adminconsole sulu:document:initialize
 
 Now executed these commands to clear any previously existing data (first you should make
 sure that you really don't need this data anymore).
 
 .. code-block:: bash
 
-    bin/adminconsole doctrine:phpcr:node:remove /cmf
-    bin/websiteconsole doctrine:phpcr:node:remove /cmf
+    php bin/adminconsole doctrine:phpcr:node:remove /cmf
+    php bin/websiteconsole doctrine:phpcr:node:remove /cmf
     # the following command can fail if the node not exist ignore the error then:
-    bin/adminconsole doctrine:phpcr:node:remove /jcr:versions
+    php bin/adminconsole doctrine:phpcr:node:remove /jcr:versions
 
 After that you can import the exported data from ``doctrinedbal`` into ``jackrabbit``
 by running the following commands:
 
 .. code-block:: bash
 
-    bin/adminconsole doctrine:phpcr:workspace:import -p / cmf.xml
-    bin/websiteconsole doctrine:phpcr:workspace:import -p / cmf_live.xml
-    bin/adminconsole doctrine:phpcr:workspace:import -p / jcr.xml
+    php bin/adminconsole doctrine:phpcr:workspace:import -p / cmf.xml
+    php bin/websiteconsole doctrine:phpcr:workspace:import -p / cmf_live.xml
+    php bin/adminconsole doctrine:phpcr:workspace:import -p / jcr.xml
 
 .. _`Jackrabbit`: https://jackrabbit.apache.org/jcr/index.html
 .. _`environment variable`: https://symfony.com/doc/4.4/configuration.html#config-env-vars

--- a/reference/components/document-manager/using_the_document_manager.rst
+++ b/reference/components/document-manager/using_the_document_manager.rst
@@ -68,7 +68,7 @@ See the :doc:`subscribers` chapter for more information.
 
     .. code-block:: bash
 
-        bin/adminconsole your:command
+        php bin/adminconsole your:command
 
 The Path Builder
 ----------------

--- a/upgrades/upgrade-1.6-2.0.rst
+++ b/upgrades/upgrade-1.6-2.0.rst
@@ -287,7 +287,7 @@ necessary should be to execute the migrations we have written:
 
 .. code-block:: bash
 
-    bin/console phpcr:migrations:migrate
+    php bin/console phpcr:migrations:migrate
 
 .. _UPGRADE.md file: https://github.com/sulu/sulu/blob/2.0.12/UPGRADE.md
 .. _sulu/skeleton: https://github.com/sulu/skeleton


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes https://github.com/sulu/sulu/issues/7603
| Related PRs | sulu/sulu#prnum
| License | MIT

#### What's in this PR?

Fix commands for none unix based terminals by prefix all commands with `php` using `bin/console` or similar.

#### Why?

Docs are mostly read by beginners. They may on windows cmd shell or other none unix based terminals which may not interpret `#!/usr/bin/env php` correctly. 