### PR TITLE
Add enable_query option in Link content type

### DIFF
--- a/reference/content-types/link.rst
+++ b/reference/content-types/link.rst
@@ -27,6 +27,9 @@ Parameters
     * - enable_attributes
       - bool
       - Enables the ``target``, ``title`` and ``rel`` input fields in the overlay. Default: ``false``
+    * - enable_query
+      - bool
+      - Enables the ``query`` input field in the overlay. Default: ``false``
     * - types
       - collection
       - List of available types in the dropdown.


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #issuenum
| Related PRs | sulu/sulu#prnum
| License | MIT

#### What's in this PR?

Adds the `enable_query` option to the documentation.

#### Why?

It was missing in the docs.
