### PR TITLE
Provide documentation also as composer package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ _build/
 *.iml
 .idea
 .DS_STORE
+
+# Composer
+/vendor/

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,7 @@
+{
+    "name": "sulu/sulu-docs",
+    "description": "The documentation for Sulu content management system based on Symfony",
+    "type": "documentation",
+    "license": "MIT",
+    "require": {}
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #issuenum
| Related PRs | sulu/sulu#prnum
| License | MIT

#### What's in this PR?

Provide documentation also as composer package.

#### Why?

Lets discuss this, I think in the raise of AI tools it make sense that somebody maybe can install the documentation via composer to give it as a context to AI tools.

The sulu docs still will not be versionized and it will only be installable as `@dev`.

```bash
composer require sulu/sulu-docs:"2.6.*@dev" --dev
```

