### PR TITLE
Add hint about cleanup temp files

### DIFF
--- a/bundles/media/imagine-adapter.rst
+++ b/bundles/media/imagine-adapter.rst
@@ -59,7 +59,7 @@ To install it use following commands:
 
 .. note::
 
-    It is very common that the `imagick` extension my not remove failed temporary files.
+    It is very common that the `imagick` extension may not remove failed temporary files.
     You can create a cronjob to clean up the temporary files if you experience issues with disk space.
     On a unix system, you can use a cronjob like this to clean up temporary files older than 60 minutes:
 

--- a/bundles/media/imagine-adapter.rst
+++ b/bundles/media/imagine-adapter.rst
@@ -14,7 +14,7 @@ Available adapters are:
 
     You may need to install additional libraries on your operating system to support various image MIME types,
     such as ``libjpeg-dev, ``libpng-dev``, ``libwebp-dev``, ``libavif-dev``.
-     
+
     Note that some Linux distributions, like Alpine, do not include these libraries in their base images by default.
 
 GD
@@ -56,6 +56,16 @@ To install it use following commands:
 
     apt-get install libmagickwand-dev
     apt-get install php8.3-imagick
+
+.. note::
+
+    It is very common that the `imagick` extension my not remove failed temporary files.
+    You can create a cronjob to clean up the temporary files if you experience issues with disk space.
+    On a unix system, you can use a cronjob like this to clean up temporary files older than 60 minutes:
+
+    .. code-block:: bash
+
+        0 * * * * find /tmp -name 'magick-*' -type f -mmin +60 -delete
 
 VIPS
 ----


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #issuenum
| Related PRs | sulu/sulu#prnum
| License | MIT

#### What's in this PR?

Add hint about cleanup temp files.

#### Why?

I discuss with Yanick from Contao CMS this issue, and they say its a common problem and if imagick is used they recommend a cronjob to cleanup old files.
