### PR TITLE
Replacing annotations with attributes

### DIFF
--- a/book/extend-admin.rst
+++ b/book/extend-admin.rst
@@ -90,33 +90,24 @@ Let's assume that we have this very simplified entity enriched with `doctrine an
 
     use Doctrine\ORM\Mapping as ORM;
 
-    /**
-     * @ORM\Entity
-     */
+    #[ORM\Entity]
     class Event
     {
         const RESOURCE_KEY = 'events';
 
-        /**
-         * @ORM\Id()
-         * @ORM\GeneratedValue()
-         * @ORM\Column(type="integer")
-         */
+        
+        #[ORM\Id]
+        #[ORM\GeneratedValue]
+        #[ORM\Column(type: 'integer')]
         private $id;
 
-        /**
-         * @ORM\Column(type="string")
-         */
+        #[ORM\Column(type: 'string')]
         private $name;
 
-        /**
-         * @ORM\Column(type="datetime_immutable")
-         */
+        #[ORM\Column(type: 'datetime_immutable')]
         private $startDate;
 
-        /**
-         * @ORM\Column(type="datetime_immutable")
-         */
+        #[ORM\Column(type: 'datetime_immutable')]
         private $endDate;
     }
 

--- a/bundles/markup/index.rst
+++ b/bundles/markup/index.rst
@@ -55,7 +55,8 @@ implements the ``TagInterface``.
          *
          * @return array Tag array to replace all occurrences.
          */
-        public function parseAll($attributesByTag) {
+        public function parseAll($attributesByTag): array
+        {
             $result = [];
             foreach($attributesByTag as $tag => $attributes) {
                 $url = ; // load url via uuid from document-manager

--- a/bundles/route/index.rst
+++ b/bundles/route/index.rst
@@ -63,19 +63,13 @@ Event.php:
 
     class Event implements RoutableInterface
     {
-        /**
-         * @var string
-         */
-        private $title;
+        private string $title;
 
-        /**
-         * @var RouteInterface
-         */
-        private $route;
+        private RouteInterface $route;
 
-        public function getTitle() { ... }
+        public function getTitle(): string { ... }
 
-        public function setTitle() { ... }
+        public function setTitle(string $title) { ... }
 
         /**
          * {@inheritdoc}

--- a/cookbook/extend-entities.rst
+++ b/cookbook/extend-entities.rst
@@ -27,28 +27,20 @@ Create your own Entity that extends Sulu `User` class.
     use Doctrine\ORM\Mapping as ORM;
     use Sulu\Bundle\SecurityBundle\Entity\User as SuluUser;
 
-    /**
-     * The following annotations are required for replacing the table of the extended entity:
-     *
-     * @ORM\Table(name="se_users")
-     * @ORM\Entity
+    /*
+     * The following attributes are required for replacing the table of the extended entity:
      */
+    #[ORM\Entity]
+    #[ORM\Table(name: 'se_users')]
     class User extends SuluUser
     {
-        /**
-         * @var string
-         *
-         * @ORM\Column(name="myProperty", type="string", length=255, nullable = true)
-         */
-        private $myProperty;
+        #[ORM\Column(name: 'myProperty', type: 'string', length: 255, nullable: true)]
+        private ?string $myProperty = null;
 
         /**
          * Set myProperty
-         *
-         * @param string $myProperty
-         * @return User
          */
-        public function setMyProperty($myProperty)
+        public function setMyProperty(?string $myProperty): self
         {
             $this->myProperty = $myProperty;
 
@@ -57,10 +49,8 @@ Create your own Entity that extends Sulu `User` class.
 
         /**
          * Get myProperty
-         *
-         * @return string
          */
-        public function getMyProperty()
+        public function getMyProperty(): ?string
         {
             return $this->myProperty;
         }
@@ -74,7 +64,7 @@ Create your own Entity that extends Sulu `User` class.
 
 .. warning::
 
-    The `@ORM\\Table` annotation on your entity must match the table of the extended entity.
+    The `#[ORM\\Table(...)]` attribute on your entity must match the table of the extended entity.
     Otherwise, doctrine might run into errors when querying data of the entity.
 
 Configuration

--- a/cookbook/sulu-twig-attributes.rst
+++ b/cookbook/sulu-twig-attributes.rst
@@ -20,9 +20,7 @@ attributes to your template. To do this, you can use the``TemplateAttributeResol
     #[AsController]
     class StaticController
     {
-        /**
-         * @Route("/custom", name="app_custom")
-         */
+        #[Route("/custom", name: "app_custom")]
         public function indexAction(
             TemplateAttributeResolverInterface $resolver,
             Environment $twig

--- a/reference/content-types/teaser_selection.rst
+++ b/reference/content-types/teaser_selection.rst
@@ -246,7 +246,7 @@ from a list of recipes:
          *
          * @return Teaser[] The teasers
          */
-        public function find(array $ids, $locale)
+        public function find(array $ids, $locale): array
         {
             if (0 === count($ids)) {
                 return [];


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | #844 
| Related PRs | -
| License | MIT

#### What's in this PR?
Annotations are deprecated use attributes instead.

#### Why?
Annotations are deprecated use attributes instead.
