### PR TITLE
Add initial package.json for Sulu documentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+    "name": "@sulu/sulu-docs",
+    "description": "The documentation for Sulu content management system based on Symfony",
+    "license": "MIT"
+}


### PR DESCRIPTION
This PR adds a simple package.json file to the repository.
The goal is to make it easier to install this project via npm, without requiring it to be published to the npm registry.

With this file in place, the package can be directly referenced in another project’s package.json like so:

```
{
  "dependencies": {
    "@sulu/sulu-docs": "git+https://github.com/sulu/sulu-docs.git"
  }
}
```

A composer.json already exists, so having a package.json as well would be a nice complement for JavaScript-based environments.

No functional code changes are included in this PR — only the addition of package.json for better ecosystem compatibility.