### PR TITLE
Change IP address to localhost in getting-started.rst

### DIFF
--- a/book/getting-started.rst
+++ b/book/getting-started.rst
@@ -118,7 +118,7 @@ Here is an example for using Sulu with MySQL:
 
 .. code:: bash
 
-    DATABASE_URL=mysql://db_user:db_password@127.0.0.1:3306/db_name?serverVersion=5.7
+    DATABASE_URL=mysql://db_user:db_password@localhost:3306/db_name?serverVersion=5.7
 
 When you're done with the configuration, populate the database with Sulu's
 default data:
@@ -153,10 +153,10 @@ will make sure the correct application is loaded.
 
     php -S localhost:8000 -t public/ config/router.php
 
-You can access the administration interface via http://127.0.0.1:8000/admin.
+You can access the administration interface via http://localhost:8000/admin.
 The default user and password is "admin".
 
-The web frontend can be found under http://127.0.0.1:8000.
+The web frontend can be found under http://localhost:8000.
 
 .. tip::
 


### PR DESCRIPTION
Updated database connection URLs from '127.0.0.1' to 'localhost' for consistency.

| Q | A
| --- | ---
| Fixed tickets | fixes #issuenum
| Related PRs | sulu/sulu#prnum
| License | MIT

#### What's in this PR?

Use "localhost" instead of "127.0.0.1" for universal (IPV6 or IPV4) URLs.

#### Why?

Systems only recognizing IPV6 will not accept IPV4 URLs.
