### PR TITLE
Remove wrong documentation about image formats and themes

### DIFF
--- a/book/image-formats.rst
+++ b/book/image-formats.rst
@@ -13,10 +13,6 @@ Image formats can be defined in:
 
  - `config/image-formats.xml`
 
-Or when you use the SuluThemeBundle you can define the formats in your theme folder:
-
- - `path/to/<theme>/config/image-formats.xml`
-
 The following example shows you different ways to define image formats:
 
 .. code-block:: xml


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #issuenum
| Related PRs | sulu/sulu#prnum
| License | MIT

#### What's in this PR?

Remove wrong documentation about image formats and themes.

#### Why?

This does not work and I even think about not implementing such auto mechanic as Symfony and even Doctrine removed auto discovery parts from there bundles also.

Such things should be also documentation of theme bundle not part of Sulu core.
