### PR TITLE
Add loadExcerpt to sulu_snippet_load docs

### DIFF
--- a/reference/twig-extensions/functions/sulu_snippet_load.rst
+++ b/reference/twig-extensions/functions/sulu_snippet_load.rst
@@ -12,6 +12,7 @@ Returns content array for given snippet uuid.
 
 - **uuid**: *string* - The uuid of requested content.
 - **locale**: *string* - optional: Locale to load snippet.
+- **loadExcerpt**: *boolean* - optional: Load data from excerpt tab
 
 **Returns**:
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #issuenum
| Related PRs | sulu/sulu#prnum
| License | MIT

#### What's in this PR?

This PR adds the loadExcerpt parameter to the sulu_snippet_load documentation. This optional parameter is implemented, but missing in the docs.

#### Why?

For completeness.
