### PR TITLE
Add loadExcerpt to sulu_snippet_load_by_area docs

### DIFF
--- a/reference/twig-extensions/functions/sulu_snippet_load_by_area.rst
+++ b/reference/twig-extensions/functions/sulu_snippet_load_by_area.rst
@@ -13,6 +13,7 @@ Returns the content of the default snippet for the given :doc:`snippet area <../
 - **area**: *string* - The area to search for snippet.
 - **webspaceKey**: *string* - optional: The webspace to get area snippet settings.
 - **locale**: *string* - optional: The locale to load snippet.
+- **loadExcerpt**: *boolean* - optional: Load data from excerpt tab
 
 **Returns**:
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets |
| Related PRs | sulu/sulu#8581
| License | MIT

#### What's in this PR?

This PR adds the loadExcerpt parameter to the sulu_snippet_load_by_area documentation. This optional parameter is implemented in sulu/sulu#8581.
This PR should only be merged, if the core PR is merged.

#### Why?

This is neccessary, because the above mentiond PR introduces a new parameter
