### PR TITLE
Update supported NPM version in requirements

### DIFF
--- a/reference/requirements.rst
+++ b/reference/requirements.rst
@@ -33,7 +33,7 @@ If you want to build parts of the admin on your own, you will additionally need:
 * `Node.js`_
 * `npm`_ >=8
 
-Also check the ``assets/admin/package.json`` file for all supported versions of package managers.
+Also check the ``assets/admin/package.json`` file for all supported versions and alternative package managers.
 For Sulu <= 2.5, you will need to use npm 6.
 
 .. _PHP: http://php.net

--- a/reference/requirements.rst
+++ b/reference/requirements.rst
@@ -33,8 +33,8 @@ If you want to build parts of the admin on your own, you will additionally need:
 * `Node.js`_
 * `npm`_ >=8
 
-Also check the ``assets/admin/package.json`` file for all supported Versions of package managers.
-For Sulu <= 2.5, you will need npm to use 6.
+Also check the ``assets/admin/package.json`` file for all supported versions of package managers.
+For Sulu <= 2.5, you will need to use npm 6.
 
 .. _PHP: http://php.net
 .. _xml_extension: http://php.net/manual/en/book.xml.php

--- a/reference/requirements.rst
+++ b/reference/requirements.rst
@@ -28,10 +28,13 @@ The following requirements are optional:
 Development Requirements
 ------------------------
 
-If you want to build parts of the system on your own, you will additionally need:
+If you want to build parts of the admin on your own, you will additionally need:
 
 * `Node.js`_
-* `npm`_ 6
+* `npm`_ >=8
+
+Also check the ``assets/admin/package.json`` file for all supported Versions of package managers.
+For Sulu <= 2.5, you will need npm to use 6.
 
 .. _PHP: http://php.net
 .. _xml_extension: http://php.net/manual/en/book.xml.php


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #issuenum
| Related PRs | sulu/sulu#prnum
| License | MIT

#### What's in this PR?

Update supported NPM version in requirements.

#### Why?

NPM 6 only required on Sulu <=2.5. Since 2.6 we supported a wide range of package managers.