### PR TITLE
Update smart content documentation

### DIFF
--- a/book/smart-content.rst
+++ b/book/smart-content.rst
@@ -142,12 +142,9 @@ The smart content supports pagination, which can be activated with the param
     </div>
 
 The view variable ``page`` contains the current page number (default: 1) and
-``hasNextPage`` is a flag which is true if another page exists.
-
-.. warning::
-    To avoid performance issues it is not possible to get a number of maximum
-    page because the system would have to load the whole content of each page
-    to determine how many pages would fit to the filters.
+``hasNextPage`` is a flag which is true if another page exists. Additionally,
+``total`` provides the total number of matching items and ``maxPage`` provides
+the maximum page number.
 
 If you want to use different parameters for different smart content on the same
 page you can define the GET-parameter with the property param

--- a/cookbook/smart-content-data-provider.rst
+++ b/cookbook/smart-content-data-provider.rst
@@ -235,7 +235,7 @@ The ``Builder`` class provides these methods to configure your provider:
 3. Service Definition
 ~~~~~~~~~~~~~~~~~~~~~
 
-Register the provider as a service with the ``sulu.smart_content.data_provider`` tag:
+Register the provider as a service with the ``sulu_content.smart_content_provider`` tag:
 
 .. code-block:: yaml
 
@@ -245,9 +245,9 @@ Register the provider as a service with the ``sulu.smart_content.data_provider``
             arguments:
                 - '@App\Repository\ExampleRepository'
             tags:
-                - { name: 'sulu.smart_content.data_provider', alias: 'examples' }
+                - { name: 'sulu_content.smart_content_provider', type: 'examples' }
 
-The ``alias`` must match the value returned by ``getType()``.
+The ``type`` attribute must match the value returned by ``getType()``.
 
 Afterwards you can use your new SmartContentProvider in your templates by setting
 the ``provider`` parameter to ``examples``.

--- a/cookbook/smart-content-data-provider.rst
+++ b/cookbook/smart-content-data-provider.rst
@@ -137,10 +137,12 @@ Create a SmartContentProvider by implementing the ``SmartContentProviderInterfac
 
     namespace App\SmartContent;
 
+    use App\Entity\Example;
+    use App\Repository\ExampleRepository;
+    use App\ResourceLoader\ExampleResourceLoader;
     use Sulu\Bundle\AdminBundle\SmartContent\Configuration\Builder;
     use Sulu\Bundle\AdminBundle\SmartContent\Configuration\ProviderConfigurationInterface;
     use Sulu\Bundle\AdminBundle\SmartContent\SmartContentProviderInterface;
-    use App\Repository\ExampleRepository;
 
     class ExampleSmartContentProvider implements SmartContentProviderInterface
     {
@@ -173,9 +175,20 @@ Create a SmartContentProvider by implementing the ``SmartContentProviderInterfac
             return $this->repository->countByFilters($filters);
         }
 
+        /**
+         * @return array<array{id: string, title: string}>
+         */
         public function findFlatBy(array $filters, array $sortBys, array $params = []): array
         {
-            return $this->repository->findByFilters($filters, $sortBys, $params);
+            $entities = $this->repository->findByFilters($filters, $sortBys, $params);
+
+            return array_map(
+                static fn (Example $entity) => [
+                    'id' => (string) $entity->getId(),
+                    'title' => $entity->getTitle(),
+                ],
+                $entities,
+            );
         }
 
         public function getType(): string
@@ -185,9 +198,18 @@ Create a SmartContentProvider by implementing the ``SmartContentProviderInterfac
 
         public function getResourceLoaderKey(): string
         {
-            return 'examples';
+            return ExampleResourceLoader::RESOURCE_LOADER_KEY;
         }
     }
+
+.. note::
+
+    ``findFlatBy`` must return a list of ``['id' => ..., 'title' => ...]`` arrays. Sulu
+    only uses these IDs to determine which records the SmartContent should render and
+    then delegates the actual loading to the ``ResourceLoader`` identified by
+    ``getResourceLoaderKey()``. The matching ``ResourceLoader`` must implement
+    ``Sulu\Content\Application\ResourceLoader\Loader\ResourceLoaderInterface`` and is
+    auto-tagged via ``sulu_content.resource_loader``.
 
 Configuration Builder Methods
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/cookbook/smart-content-data-provider.rst
+++ b/cookbook/smart-content-data-provider.rst
@@ -15,7 +15,7 @@ This configuration array includes the following values:
     * - dataSource
       - Additional constraint - like page-"folder".
     * - tags
-      - Multiple selection of tags, which an item should have.
+      - Array of selected tag IDs (``int[]``) the item should have.
     * - tagOperator
       - The item has any or all of the selected tags.
     * - categories

--- a/reference/property-types/smart_content.rst
+++ b/reference/property-types/smart_content.rst
@@ -17,10 +17,11 @@ return the items that match these filters. There are several built-in providers
 and you can add your own SmartContentProvider easily. How you can do this is
 described in :doc:`/cookbook/smart-content-data-provider`
 
-A very important feature is the ``exclude_duplicates`` parameter which offers
-the possibility to filter already used items on a website. If this parameter
-is set to true the smart-content uses the :doc:`/bundles/reference-store`
-to detect already used items and filters them.
+.. warning::
+
+    The ``exclude_duplicates`` parameter is not yet fully implemented in Sulu 3.
+    While the admin UI collects excluded IDs from other smart content fields on
+    the same page, the backend does not yet filter them from query results.
 
 Parameters
 ----------
@@ -117,17 +118,14 @@ This values are available in the *view* variable in the twig templates.
     * - websiteTagOperator
       - string
       - Operator which combines GET parameter tags
-    * - sortBy
-      - string
-      - Selected sort column
-    * - sortMethod
-      - string
-      - Selected sort method - ASC or DESC
+    * - sortBys
+      - array
+      - Selected sort configuration (e.g. ``{'authored': 'ASC'}``)
     * - presentAs
       - string
-      - selected present as value
+      - Selected present as value
     * - limitResult
-      - string
+      - int
       - Selected limit for result
     * - page
       - int
@@ -135,6 +133,18 @@ This values are available in the *view* variable in the twig templates.
     * - hasNextPage
       - bool
       - Is TRUE if another page exists
+    * - paginated
+      - bool
+      - Is TRUE if pagination is enabled
+    * - total
+      - int
+      - Total number of items matching the filter
+    * - maxPage
+      - int|null
+      - Maximum page number (null if pagination is disabled)
+    * - maxPerPage
+      - int|null
+      - Maximum items per page (null if pagination is disabled)
 
 The "content" values depends on the SmartContentProvider.
 
@@ -227,6 +237,32 @@ This provider filters snippets.
     * - properties
       - collection
       - Defines the property names which will be exposed in the HTML template.
+
+Articles
+~~~~~~~~
+
+Alias: "articles"
+
+This provider filters articles. Requires the SuluArticleBundle to be installed.
+
+**Parameters**
+
+.. list-table::
+    :header-rows: 1
+
+    * - Parameter
+      - Type
+      - Description
+    * - properties
+      - collection
+      - Defines the property names which will be exposed in the HTML template.
+
+.. note::
+
+    The ``types`` filter for articles corresponds to article groups (types),
+    not template keys. The ``properties`` parameter works the same way as for
+    pages, supporting both template properties and extension data
+    (e.g. ``excerpt.title``).
 
 Contact - People
 ~~~~~~~~~~~~~~~~
@@ -346,11 +382,18 @@ Twig template
                 </h2>
 
                 <p>
+                    <time datetime="{{ page.authored|date('Y-m-d') }}">{{ page.authored|date('M d, Y') }}</time>
+                    {% if page.lastModified %}
+                        | Last modified: {{ page.lastModified|date('M d, Y') }}
+                    {% endif %}
+                </p>
+
+                <p>
                     <i>{{ page.excerptTitle }}</i> | <i>{{ page.excerptTags|join(', ') }}</i>
                 </p>
 
-                {% if page.excerptImages|length > 0 %}
-                    <img src="{{ page.excerptImages[0].thumbnails['50x50'] }}" alt="{{ page.excerptImages[0].title }}"/>
+                {% if page.excerptImage|length > 0 %}
+                    <img src="{{ page.excerptImage.thumbnails['50x50'] }}" alt="{{ page.excerptImage.title }}"/>
                 {% endif %}
 
                 {{ page.article|raw }}
@@ -362,6 +405,70 @@ Twig template
 
     If you have not defined the parameter ``max_per_page`` you can omit the
     pagination.
+
+.. _automatically_available_properties:
+
+Automatically available properties
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following properties are available on each smart content item **without**
+needing to be mapped in the ``properties`` parameter. They are resolved
+automatically from the entity settings:
+
+.. list-table::
+    :header-rows: 1
+
+    * - Property
+      - Type
+      - Description
+    * - authored
+      - DateTimeImmutable
+      - The authored date set by the content manager
+    * - lastModified
+      - DateTimeImmutable
+      - The last modified date (if enabled by the content manager)
+    * - author
+      - object
+      - The author contact reference
+    * - template
+      - string
+      - The template key used by the item
+    * - availableLocales
+      - string[]
+      - The locales in which the item is available
+
+Additionally, the ``title`` and ``url`` properties are included as default
+properties for the ``pages`` and ``articles`` providers, so they are always
+available without explicit mapping.
+
+.. note::
+
+    The ``properties`` parameter is used to expose **template properties**
+    (like ``article``) and **extension data** (like ``excerpt.title``) on
+    each item. Settings like ``authored`` and ``lastModified`` do not need
+    to be listed there.
+
+Available sort columns
+~~~~~~~~~~~~~~~~~~~~~~
+
+The following sort columns are available for the ``pages`` and ``articles``
+providers:
+
+.. list-table::
+    :header-rows: 1
+
+    * - Column
+      - Description
+    * - workflowPublished
+      - The date when the item was published
+    * - authored
+      - The authored date set by the content manager
+    * - created
+      - The date when the item was created in the system
+    * - changed
+      - The date when the item was last changed in the system
+    * - title
+      - The title of the item (alphabetical sorting)
 
 Built-in SmartContentProviders
 -------------------------------

--- a/reference/property-types/smart_content.rst
+++ b/reference/property-types/smart_content.rst
@@ -71,8 +71,8 @@ Parameters
       - Root category (key) to display category-tree.
     * - exclude_duplicates
       - bool
-      - If the provider is able to detect duplicates the content-type filters
-        already loaded records. Default: `false`
+      - Not yet fully implemented in Sulu 3. Intended to filter already loaded
+        records when the provider supports duplicate detection. Default: `false`
 
 Return Value
 ------------
@@ -344,7 +344,7 @@ Page template
                 <param name="authored" value="object.authored"/>
                 <param name="lastModified" value="object.lastModified"/>
                 <param name="excerptTitle" value="excerpt.title" />
-                <param name="excerptDescription" value="excerpt.description "/>
+                <param name="excerptDescription" value="excerpt.description"/>
                 <param name="excerptMore" value="excerpt.more" />
                 <param name="excerptTags" value="excerpt.tags" />
                 <param name="excerptCategories" value="excerpt.categories" />
@@ -393,7 +393,9 @@ Twig template
                 </h2>
 
                 <p>
-                    <time datetime="{{ page.authored|date('Y-m-d') }}">{{ page.authored|date('M d, Y') }}</time>
+                    {% if page.authored %}
+                        <time datetime="{{ page.authored|date('Y-m-d') }}">{{ page.authored|date('M d, Y') }}</time>
+                    {% endif %}
                     {% if page.lastModified %}
                         | Last modified: {{ page.lastModified|date('M d, Y') }}
                     {% endif %}

--- a/reference/property-types/smart_content.rst
+++ b/reference/property-types/smart_content.rst
@@ -73,6 +73,14 @@ Parameters
       - bool
       - Not yet fully implemented in Sulu 3. Intended to filter already loaded
         records when the provider supports duplicate detection. Default: `false`
+    * - groups
+      - string
+      - Articles only (``articles`` and ``articles_page_tree`` providers): comma
+        separated list of article group identifiers to pre-filter the result set.
+    * - templateKeys
+      - string
+      - Pages and snippets (``pages`` and ``snippets`` providers): comma separated
+        list of template keys to pre-filter the result set.
 
 Return Value
 ------------
@@ -98,8 +106,8 @@ This values are available in the *view* variable in the twig templates.
       - string
       - Operator which combines selected categories
     * - tags
-      - string[]
-      - Selected tags
+      - int[]
+      - Selected tag IDs
     * - tagOperator
       - string
       - Operator which combines selected tags
@@ -114,7 +122,7 @@ This values are available in the *view* variable in the twig templates.
       - Operator which combines GET parameter categories
     * - websiteTags
       - string[]
-      - Selected tags over GET parameter
+      - Selected tag names over GET parameter
     * - websiteTagOperator
       - string
       - Operator which combines GET parameter tags
@@ -264,13 +272,16 @@ This provider filters articles. Requires the SuluArticleBundle to be installed.
     * - properties
       - collection
       - Defines the property names which will be exposed in the HTML template.
+    * - groups
+      - string
+      - Comma separated list of article group identifiers to pre-filter the result
+        set. The "Type" filter shown in the SmartContent admin UI corresponds to these
+        article groups.
 
 .. note::
 
-    The ``types`` filter for articles corresponds to article groups (types),
-    not template keys. The ``properties`` parameter works the same way as for
-    pages, supporting both template properties and extension data
-    (e.g. ``excerpt.title``).
+    The ``properties`` parameter works the same way as for pages, supporting both
+    template properties and extension data (e.g. ``excerpt.title``).
 
 Contact - People
 ~~~~~~~~~~~~~~~~

--- a/reference/property-types/smart_content.rst
+++ b/reference/property-types/smart_content.rst
@@ -179,11 +179,19 @@ source, whose child pages will be filtered by the SmartContentProvider.
 
 .. note::
 
-    "properties" can include structure properties or extension data:
+    "properties" can include structure properties, extension data, or entity
+    properties using the ``object.`` prefix:
 
-    * title - is a property of the structure
-    * excerpt.title - is a property of the excerpt structure extension with
-      the name title
+    * ``title`` - a template property
+    * ``excerpt.title`` - a property of the excerpt extension
+    * ``object.resource.uuid`` - reads the UUID from the underlying resource entity
+    * ``object.authored`` - reads ``authored`` directly from the entity
+    * ``object.lastModified`` - reads ``lastModified`` directly from the entity
+
+    The ``object.`` prefix uses the PropertyAccessor to read any getter on the
+    DimensionContent entity (or nested objects like ``resource``). This includes
+    properties from ``AuthorTrait`` (``authored``, ``lastModified``, ``author``)
+    and ``AuditableTrait`` (``created``, ``changed``).
 
     For an example see :ref:`example`
 
@@ -332,6 +340,9 @@ Page template
 
             <param name="properties" type="collection">
                 <param name="article" value="article"/>
+                <param name="uuid" value="object.resource.uuid"/>
+                <param name="authored" value="object.authored"/>
+                <param name="lastModified" value="object.lastModified"/>
                 <param name="excerptTitle" value="excerpt.title" />
                 <param name="excerptDescription" value="excerpt.description "/>
                 <param name="excerptMore" value="excerpt.more" />
@@ -406,47 +417,12 @@ Twig template
     If you have not defined the parameter ``max_per_page`` you can omit the
     pagination.
 
-.. _automatically_available_properties:
+Default properties
+~~~~~~~~~~~~~~~~~~
 
-Automatically available properties
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The following properties are available on each smart content item **without**
-needing to be mapped in the ``properties`` parameter. They are resolved
-automatically from the entity settings:
-
-.. list-table::
-    :header-rows: 1
-
-    * - Property
-      - Type
-      - Description
-    * - authored
-      - DateTimeImmutable
-      - The authored date set by the content manager
-    * - lastModified
-      - DateTimeImmutable
-      - The last modified date (if enabled by the content manager)
-    * - author
-      - object
-      - The author contact reference
-    * - template
-      - string
-      - The template key used by the item
-    * - availableLocales
-      - string[]
-      - The locales in which the item is available
-
-Additionally, the ``title`` and ``url`` properties are included as default
-properties for the ``pages`` and ``articles`` providers, so they are always
-available without explicit mapping.
-
-.. note::
-
-    The ``properties`` parameter is used to expose **template properties**
-    (like ``article``) and **extension data** (like ``excerpt.title``) on
-    each item. Settings like ``authored`` and ``lastModified`` do not need
-    to be listed there.
+The ``title`` and ``url`` properties are included as default properties for
+the ``pages`` and ``articles`` providers, so they are always available
+without explicit mapping in the ``properties`` parameter.
 
 Available sort columns
 ~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #issuenum
| Related PRs | sulu/sulu#prnum
| License | MIT

#### What's in this PR?

Updates the documentation to be compatible with Sulu 3.0

#### Why?

The documentation still had wrong Sulu 2.6 content.
