### PR TITLE
Update Paths to github from 2.x to 2.6

### DIFF
--- a/book/templates.rst
+++ b/book/templates.rst
@@ -1089,7 +1089,7 @@ with :doc:`twig` to learn more about rendering this structure as HTML.
 .. _XPointer: https://en.wikipedia.org/wiki/XPointer
 .. _Symfony's naming convention: http://symfony.com/doc/current/templating.html#template-naming-and-locations
 .. _cron expression: https://github.com/dragonmantank/cron-expression
-.. _Media: https://github.com/sulu/sulu/blob/2.x/src/Sulu/Bundle/MediaBundle/Api/Media.php
+.. _Media: https://github.com/sulu/sulu/blob/2.6/src/Sulu/Bundle/MediaBundle/Api/Media.php
 .. _Jexl: https://github.com/TomFrost/Jexl
 
 .. |text_line| replace:: :doc:`text_line <../reference/content-types/text_line>`

--- a/book/twig.rst
+++ b/book/twig.rst
@@ -192,5 +192,5 @@ CSS / JS
 You can organize and build your website assets the way you are most familiar with.
 If you want to use Symfony's Webpack Encore, have a look at the :doc:`../cookbook/webpack-encore`.
 
-.. _image_formats.xml: https://github.com/sulu/skeleton/blob/2.x/config/image-formats.xml
+.. _image_formats.xml: https://github.com/sulu/skeleton/blob/2.6/config/image-formats.xml
 .. _Sulu Homepage: http://sulu.io

--- a/bundles/activity.rst
+++ b/bundles/activity.rst
@@ -221,6 +221,6 @@ The `createActivityListViewBuilder` method is used to create the view. It takes 
 The setParent method sets the parent view to integrate the activities table into the existing admin view.
 
 .. _Symfony event dispatcher: https://symfony.com/doc/current/event_dispatcher.html
-.. _DomainEvent class: https://github.com/sulu/sulu/blob/2.x/src/Sulu/Bundle/ActivityBundle/Domain/Event/DomainEvent.php
-.. _ActivityController class: https://github.com/sulu/sulu/blob/2.x/src/Sulu/Bundle/ActivityBundle/UserInterface/Controller/ActivityController.php#L377-L401
+.. _DomainEvent class: https://github.com/sulu/sulu/blob/2.6/src/Sulu/Bundle/ActivityBundle/Domain/Event/DomainEvent.php
+.. _ActivityController class: https://github.com/sulu/sulu/blob/2.6/src/Sulu/Bundle/ActivityBundle/UserInterface/Controller/ActivityController.php#L377-L401
 .. _Symfony translations: https://symfony.com/doc/current/translation.html

--- a/bundles/trash.rst
+++ b/bundles/trash.rst
@@ -220,11 +220,11 @@ drive or related data in an external system.
     However, if you've created a custom ``TrashItemHandler`` with the restore functionality in a separate bundle,
     be sure to tag the service also with ``sulu_trash.remove_trash_item_handler`` to ensure proper functionality.
 
-.. _TrashItem entity: https://github.com/sulu/sulu/blob/2.x/src/Sulu/Bundle/TrashBundle/Domain/Model/TrashItem.php
-.. _TrashManager service: https://github.com/sulu/sulu/blob/2.x/src/Sulu/Bundle/TrashBundle/Application/TrashManager/TrashManager.php
-.. _StoreTrashItemHandlerInterface interface: https://github.com/sulu/sulu/blob/2.x/src/Sulu/Bundle/TrashBundle/Application/TrashItemHandler/StoreTrashItemHandlerInterface.php
-.. _RestoreTrashItemHandlerInterface interface: https://github.com/sulu/sulu/blob/2.x/src/Sulu/Bundle/TrashBundle/Application/TrashItemHandler/RestoreTrashItemHandlerInterface.php
-.. _RemoveTrashItemHandlerInterface interface: https://github.com/sulu/sulu/blob/2.x/src/Sulu/Bundle/TrashBundle/Application/TrashItemHandler/RemoveTrashItemHandlerInterface.php
-.. _RestoreConfiguration object: https://github.com/sulu/sulu/blob/2.x/src/Sulu/Bundle/TrashBundle/Application/RestoreConfigurationProvider/RestoreConfiguration.php
-.. _RestoreConfigurationProviderInterface interface: https://github.com/sulu/sulu/blob/2.x/src/Sulu/Bundle/TrashBundle/Application/RestoreConfigurationProvider/RestoreConfigurationProviderInterface.php
+.. _TrashItem entity: https://github.com/sulu/sulu/blob/2.6/src/Sulu/Bundle/TrashBundle/Domain/Model/TrashItem.php
+.. _TrashManager service: https://github.com/sulu/sulu/blob/2.6/src/Sulu/Bundle/TrashBundle/Application/TrashManager/TrashManager.php
+.. _StoreTrashItemHandlerInterface interface: https://github.com/sulu/sulu/blob/2.6/src/Sulu/Bundle/TrashBundle/Application/TrashItemHandler/StoreTrashItemHandlerInterface.php
+.. _RestoreTrashItemHandlerInterface interface: https://github.com/sulu/sulu/blob/2.6/src/Sulu/Bundle/TrashBundle/Application/TrashItemHandler/RestoreTrashItemHandlerInterface.php
+.. _RemoveTrashItemHandlerInterface interface: https://github.com/sulu/sulu/blob/2.6/src/Sulu/Bundle/TrashBundle/Application/TrashItemHandler/RemoveTrashItemHandlerInterface.php
+.. _RestoreConfiguration object: https://github.com/sulu/sulu/blob/2.6/src/Sulu/Bundle/TrashBundle/Application/RestoreConfigurationProvider/RestoreConfiguration.php
+.. _RestoreConfigurationProviderInterface interface: https://github.com/sulu/sulu/blob/2.6/src/Sulu/Bundle/TrashBundle/Application/RestoreConfigurationProvider/RestoreConfigurationProviderInterface.php
 .. _services.yaml configuration from Symfony: https://symfony.com/doc/6.4/service_container.html#service-container-services-load-example

--- a/cookbook/build-admin-frontend.rst
+++ b/cookbook/build-admin-frontend.rst
@@ -135,7 +135,7 @@ If this does not solve the problem, you can try to clean the npm cache on your m
     npm cache clean --force
 
 .. _issue in the sulu/skeleton repository: https://github.com/sulu/skeleton/issues/88
-.. _Test Application workflow: https://github.com/sulu/sulu/blob/2.x/.github/workflows/test-application.yaml
+.. _Test Application workflow: https://github.com/sulu/sulu/blob/2.6/.github/workflows/test-application.yaml
 .. _sulu/skeleton repository: https://github.com/sulu/skeleton
 .. _node: https://nodejs.org/en/
 .. _bun: https://bun.sh/

--- a/cookbook/maintenance-mode.rst
+++ b/cookbook/maintenance-mode.rst
@@ -66,4 +66,4 @@ exists the default locale is being used. By default this is English:
     <?php
     define('DEFAULT_LOCALE', 'en');
 
-.. _public/maintenance.php: https://github.com/sulu/skeleton/blob/2.x/public/maintenance.php
+.. _public/maintenance.php: https://github.com/sulu/skeleton/blob/2.6/public/maintenance.php

--- a/reference/content-types/account_selection.rst
+++ b/reference/content-types/account_selection.rst
@@ -64,5 +64,5 @@ Twig
         <h3>{{ account.name }}</h3>
     {% endfor %}
 
-.. _Account: https://github.com/sulu/sulu/blob/2.x/src/Sulu/Bundle/ContactBundle/Api/Account.php
+.. _Account: https://github.com/sulu/sulu/blob/2.6/src/Sulu/Bundle/ContactBundle/Api/Account.php
 .. _jexl: https://github.com/TomFrost/jexl

--- a/reference/content-types/collection_selection.rst
+++ b/reference/content-types/collection_selection.rst
@@ -66,6 +66,6 @@ Twig
         <h3>{{ collection.title }}</h3>
     {% endfor %}
 
-.. _Collection: https://github.com/sulu/sulu/blob/2.x/src/Sulu/Bundle/MediaBundle/Api/Collection.php
+.. _Collection: https://github.com/sulu/sulu/blob/2.6/src/Sulu/Bundle/MediaBundle/Api/Collection.php
 .. _custom twig extension: https://symfony.com/doc/current/templating/twig_extension.html
 .. _jexl: https://github.com/TomFrost/jexl

--- a/reference/content-types/contact_selection.rst
+++ b/reference/content-types/contact_selection.rst
@@ -64,5 +64,5 @@ Twig
         <h3>{{ contact.fullName }}</h3>
     {% endfor %}
 
-.. _ContactInterface: https://github.com/sulu/sulu/blob/2.x/src/Sulu/Bundle/ContactBundle/Entity/ContactInterface.php
+.. _ContactInterface: https://github.com/sulu/sulu/blob/2.6/src/Sulu/Bundle/ContactBundle/Entity/ContactInterface.php
 .. _jexl: https://github.com/TomFrost/jexl

--- a/reference/content-types/single_account_selection.rst
+++ b/reference/content-types/single_account_selection.rst
@@ -63,5 +63,5 @@ the account logo image.
         <img src="{{ image.thumbnails['80x80'] }}" alt="{{ account.name }}">
     {% endif
 
-.. _Account: https://github.com/sulu/sulu/blob/2.x/src/Sulu/Bundle/ContactBundle/Api/Account.php
+.. _Account: https://github.com/sulu/sulu/blob/2.6/src/Sulu/Bundle/ContactBundle/Api/Account.php
 .. _jexl: https://github.com/TomFrost/jexl

--- a/reference/content-types/single_collection_selection.rst
+++ b/reference/content-types/single_collection_selection.rst
@@ -61,6 +61,6 @@ Twig
 
     {{ content.collection.fullName }}
 
-.. _Collection: https://github.com/sulu/sulu/blob/2.x/src/Sulu/Bundle/MediaBundle/Api/Collection.php
+.. _Collection: https://github.com/sulu/sulu/blob/2.6/src/Sulu/Bundle/MediaBundle/Api/Collection.php
 .. _custom twig extension: https://symfony.com/doc/current/templating/twig_extension.html
 .. _jexl: https://github.com/TomFrost/jexl

--- a/reference/content-types/single_contact_selection.rst
+++ b/reference/content-types/single_contact_selection.rst
@@ -63,5 +63,5 @@ the contact avatar image.
         <img src="{{ image.thumbnails['80x80'] }}" alt="{{ contact.fullName }}">
     {% endif %}
 
-.. _ContactInterface: https://github.com/sulu/sulu/blob/2.x/src/Sulu/Bundle/ContactBundle/Entity/ContactInterface.php
+.. _ContactInterface: https://github.com/sulu/sulu/blob/2.6/src/Sulu/Bundle/ContactBundle/Entity/ContactInterface.php
 .. _jexl: https://github.com/TomFrost/jexl

--- a/reference/content-types/single_media_selection.rst
+++ b/reference/content-types/single_media_selection.rst
@@ -109,5 +109,5 @@ to control which `disposition header`_ the target url should use:
     website. Always use ``thumbnails`` and :doc:`configure your image formats <../../../book/image-formats>`
     to provide fast optimized cacheable images.
 
-.. _Media: https://github.com/sulu/sulu/blob/2.x/src/Sulu/Bundle/MediaBundle/Api/Media.php
+.. _Media: https://github.com/sulu/sulu/blob/2.6/src/Sulu/Bundle/MediaBundle/Api/Media.php
 .. _`disposition header`: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition

--- a/upgrades/upgrade-2.x.rst
+++ b/upgrades/upgrade-2.x.rst
@@ -114,4 +114,4 @@ To simplify this step, Sulu provides a command to update the JavaScript build in
 .. _Composer documentation: https://getcomposer.org/doc/articles/versions.md#writing-version-constraints
 .. _sulu/skeleton repository: https://github.com/sulu/skeleton
 .. _Symfony best practices: https://symfony.com/doc/current/best_practices.html
-.. _UPGRADE.md file: https://github.com/sulu/sulu/blob/2.x/UPGRADE.md
+.. _UPGRADE.md file: https://github.com/sulu/sulu/blob/2.6/UPGRADE.md


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #issuenum
| Related PRs | sulu/sulu#prnum
| License | MIT

#### What's in this PR?

This PR fixes references to Github code. 

#### Why?

Since the 2.5 has been deleted, and the previously called 2.x branch was renamed to 2.5 all references to 2.x on github redirect to the 2.5 branch. This results in a 404. To make the references work again, I changed all the 2.x references to 2.6.
