### PR TITLE
Update Paths to github from 2.5 to 2.6

### DIFF
--- a/bundles/test.rst
+++ b/bundles/test.rst
@@ -138,6 +138,6 @@ it in ``setUpBeforeClass()`` instead of ``setUp()``.
 
 
 .. _test documentation: https://symfony.com/doc/current/testing.html
-.. _KernelTestCase: https://github.com/sulu/sulu/blob/2.5/src/Sulu/Bundle/TestBundle/Testing/KernelTestCase.php
-.. _SuluTestCase: https://github.com/sulu/sulu/blob/2.5/src/Sulu/Bundle/TestBundle/Testing/SuluTestCase.php
+.. _KernelTestCase: https://github.com/sulu/sulu/blob/2.6/src/Sulu/Bundle/TestBundle/Testing/KernelTestCase.php
+.. _SuluTestCase: https://github.com/sulu/sulu/blob/2.6/src/Sulu/Bundle/TestBundle/Testing/SuluTestCase.php
 .. _DOM Crawler: https://symfony.com/doc/current/testing/dom_crawler.html


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #issuenum
| Related PRs | #893
| License | MIT

#### What's in this PR?

This PR updates references from github code from 2.5 branch to 2.6

#### Why?

Same Problem as in #893. The paths were leading to a 404 page.
