### PR TITLE
Document 'rows' attribute for text area

### DIFF
--- a/reference/content-types/text_area.rst
+++ b/reference/content-types/text_area.rst
@@ -27,7 +27,9 @@ Parameters
     * - pattern
       - string
       - A regex pattern the must be fulfilled by the entered data (e.g. "^[a-zA-Z]*$" will only allow letters)
-
+    * - rows
+      - integer
+      - Desired amount of visible height, in lines
 Example
 -------
 

--- a/reference/content-types/text_area.rst
+++ b/reference/content-types/text_area.rst
@@ -30,6 +30,7 @@ Parameters
     * - rows
       - integer
       - Desired amount of visible height, in lines
+
 Example
 -------
 


### PR DESCRIPTION
Add 'rows' attribute to text area content type documentation.

The feature was implemented [some while ago](https://github.com/sulu/sulu/pull/7614) but never made it into the docs.

Also relevant for `3.x`.

| Q | A
| --- | ---
| Related PRs | [sulu/sulu#7614](https://github.com/sulu/sulu/pull/7614)
| License | MIT

#### Why?

Was missing previously.
