### PR TITLE
Upgrade Sulu 3.0 block settings key and file name

### DIFF
--- a/reference/property-types/block.rst
+++ b/reference/property-types/block.rst
@@ -167,7 +167,7 @@ Extending default block settings for pages
 ------------------------------------------
 
 If you want to add a custom field to the block settings for pages, you can extend
-the ``page_block_settings`` form by creating a ``config/forms/page_block_settings``:
+the ``content_block_settings`` form by creating a ``config/forms/content_block_settings``:
 
 .. code-block:: xml
 
@@ -176,7 +176,7 @@ the ``page_block_settings`` form by creating a ``config/forms/page_block_setting
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/form-1.0.xsd"
     >
-        <key>page_block_settings</key>
+        <key>content_block_settings</key>
 
         <properties>
             <section name="custom">


### PR DESCRIPTION
Adjusts form key and file name for custom block settings according to https://github.com/sulu/sulu/pull/8449

| Q | A
| --- | ---
| Fixed tickets | fixes #issuenum
| Related PRs | sulu/sulu#prnum
| License | MIT

#### What's in this PR?

This PR adjusts form key and file name for custom block settings according to the BC in Sulu 3.0

#### Why?

Key and file name for custom block settings have changed in Sulu 3.0 but the documentation has not been updated for this case.
